### PR TITLE
Removed v6 obsoletes

### DIFF
--- a/src/NServiceBus.Gateway/Receiving/SingleCallChannelReceiver.cs
+++ b/src/NServiceBus.Gateway/Receiving/SingleCallChannelReceiver.cs
@@ -88,11 +88,6 @@
                 {
                     args.Headers = MapCustomMessageHeaders(headers);
                 }
-                
-                if (IsMsmqTransport)
-                {
-                    args.Headers[Headers.CorrelationId] = StripSlashZeroFromCorrelationId(args.Headers[Headers.CorrelationId]);
-                }
           
                 var body = new byte[stream.Length];
                 await stream.ReadAsync(body, 0, body.Length).ConfigureAwait(false);
@@ -181,8 +176,6 @@
             return result;
         }
 
-        public bool IsMsmqTransport{ get; set; }
-
         async Task HandleDatabusProperty(CallInfo callInfo)
         {
             if (databus == null)
@@ -202,39 +195,22 @@
             var specificDataBusHeaderToUpdate = callInfo.ReadDataBus();
             headerManager.InsertHeader(callInfo.ClientId, specificDataBusHeaderToUpdate, newDatabusKey);
         }
-
-        static string StripSlashZeroFromCorrelationId(string corrId)
-        {
-            if (corrId == null)
-            {
-                return null;
-            }
-
-            if (corrId.EndsWith("\\0"))
-            {
-                return corrId.Replace("\\0", string.Empty);
-            }
-
-            return corrId;
-        }
-
-
+        
         static ILog Logger = LogManager.GetLogger("NServiceBus.Gateway");
 
         Func<string, IChannelReceiver> channelFactory;
         IDeduplicateMessages deduplicator;
         readonly IDataBus databus;
         DataBusHeaderManager headerManager;
-
         IChannelReceiver channelReceiver;
 
         const string NServiceBus = "NServiceBus.";
         const string Id = "Id";
-        
         const string CorrelationId = "CorrelationId";
         const string Recoverable = "Recoverable";
         const string TimeToBeReceived = "TimeToBeReceived";
         static readonly TimeSpan MinimumTimeToBeReceived = TimeSpan.FromSeconds(1);
+
         Func<MessageReceivedOnChannelArgs, Task> messageReceivedHandler;
     }
 }


### PR DESCRIPTION
This code was marked as [obsolete for version 6](https://github.com/Particular/NServiceBus/commit/a94795497153a6152e78f34061c548b5c19b0d61), but this got lost in translation when the code was moved from [core](https://github.com/Particular/NServiceBus/blob/46f5a2acee424a94a62fbd5645e093635c09cdd9/src/NServiceBus.Core/Gateway/HeaderManagement/HeaderMapper.cs) to its own [gateway package](https://github.com/Particular/NServiceBus.Gateway/blob/18dbba91993c878ec80b2c9a32d46415cf7638bd/src/NServiceBus.Gateway/HeaderManagement/HeaderMapper.cs).

The code never worked in version 5 because of missing initialization of the `IsMsmqProperty`, but [not fixing it](https://github.com/Particular/NServiceBus.Gateway/pull/35) as it is obsolete now anyway.

Removing it all.