### PR TITLE
Add getter for RouteToSites extension

### DIFF
--- a/src/NServiceBus.Gateway.Tests/NServiceBus.Gateway.Tests.csproj
+++ b/src/NServiceBus.Gateway.Tests/NServiceBus.Gateway.Tests.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Receiving\HasherTests.cs" />
     <Compile Include="Routing\When_routing_a_reply_message.cs" />
     <Compile Include="Routing\When_routing_using_the_configuration_source.cs" />
+    <Compile Include="SendOptionsExtensionsTests.cs" />
     <Compile Include="StringStreamExtensions.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NServiceBus.Gateway.Tests/SendOptionsExtensionsTests.cs
+++ b/src/NServiceBus.Gateway.Tests/SendOptionsExtensionsTests.cs
@@ -1,0 +1,35 @@
+﻿namespace NServiceBus.Gateway.Tests
+{
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class SendOptionsExtensionsTests
+    {
+        [Test]
+        public void GetSitesRoutingTo_WhenNoSitesConfigured_ShouldReturnEmptyArray()
+        {
+            var sendOptions = new SendOptions();
+
+            var sites = sendOptions.GetSitesRoutingTo();
+
+            Assert.IsEmpty(sites);
+        }
+
+        [Test]
+        public void GetSitesRoutingTo_WhenRoutingToSites_ShouldReturnConfiguredSites()
+        {
+            var sendOptions = new SendOptions();
+            var expectedSites = new[]
+            {
+                "site A",
+                "",
+                "site B"
+            };
+
+            sendOptions.RouteToSites(expectedSites);
+            var sites = sendOptions.GetSitesRoutingTo();
+
+            CollectionAssert.AreEqual(expectedSites, sites);
+        }
+    }
+}

--- a/src/NServiceBus.Gateway/SendOptionsExtensions.cs
+++ b/src/NServiceBus.Gateway/SendOptionsExtensions.cs
@@ -1,23 +1,39 @@
 namespace NServiceBus
 {
+    using System;
     using Extensibility;
     using Gateway.Routing;
 
     /// <summary>
-    /// 
+    /// Extensions to <see cref="SendOptions"/> provided by the Gateway.
     /// </summary>
     public static class SendOptionsExtensions
     {
         /// <summary>
-        /// 
+        /// Route the message through the Gateway to the specified sites.
         /// </summary>
-        /// <param name="options"></param>
-        /// <param name="siteKeys"></param>
         public static void RouteToSites(this SendOptions options, params string[] siteKeys)
         {
             options.SetHeader(Headers.DestinationSites, string.Join(",", siteKeys));
             options.GetExtensions().Set(new RouteThroughGateway());
             options.RouteToThisEndpoint();
+        }
+
+        /// <summary>
+        /// Retrieves the sites configured by <see cref="RouteToSites"/>.
+        /// </summary>
+        public static string[] GetSitesRoutingTo(this SendOptions options)
+        {
+            string siteKeys;
+            if (options.GetHeaders().TryGetValue(Headers.DestinationSites, out siteKeys))
+            {
+                return siteKeys.Split(new[]
+                {
+                    ","
+                }, StringSplitOptions.None);
+            }
+
+            return new string[0];
         }
     }
 }


### PR DESCRIPTION
Add getter extension method for SendOptions to retrieve the sites configured by RouteToSites. This is required for unit tests to verify RouteToSites usage.

@Particular/nservicebus-maintainers @hmemcpy @mat-mcloughlin please review

Connects to Particular/NServiceBus.Testing#29