### PR TITLE
Fixed ChannelFactories signature

### DIFF
--- a/src/NServiceBus.Gateway.Tests/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Gateway.Tests/APIApprovals.Approve.approved.txt
@@ -15,7 +15,7 @@ namespace NServiceBus
     }
     public class GatewaySettings
     {
-        public void ChannelFactories(System.Func<string, NServiceBus.Gateway.IChannelSender> senderFactory, System.Func<string, NServiceBus.Gateway.IChannelSender> receiverFactory) { }
+        public void ChannelFactories(System.Func<string, NServiceBus.Gateway.IChannelSender> senderFactory, System.Func<string, NServiceBus.Gateway.IChannelReceiver> receiverFactory) { }
         public void CustomRetryPolicy(System.Func<NServiceBus.Transports.IncomingMessage, System.Exception, int, System.TimeSpan> customRetryPolicy) { }
         public void DisableRetries() { }
         public void Retries(int numberOfRetries, System.TimeSpan timeIncrease) { }

--- a/src/NServiceBus.Gateway/Settings/GatewaySettings.cs
+++ b/src/NServiceBus.Gateway/Settings/GatewaySettings.cs
@@ -22,7 +22,7 @@
         /// </summary>
         /// <param name="senderFactory">The sender factory to use. The factory takes a string with the channel type as parameter.</param>
         /// <param name="receiverFactory">The receiver factory to use. The factory takes a string with the channel type as parameter.</param>
-        public void ChannelFactories(Func<string, IChannelSender> senderFactory, Func<string, IChannelSender> receiverFactory)
+        public void ChannelFactories(Func<string, IChannelSender> senderFactory, Func<string, IChannelReceiver> receiverFactory)
         {
             if (senderFactory == null)
             {


### PR DESCRIPTION
The receive channel func was set to return an `IChannelSender` instead of `IChannelReceiver`