### PR TITLE
[WIP] Allow response to V3 gateway requests

### DIFF
--- a/src/NServiceBus.Gateway/CallType.cs
+++ b/src/NServiceBus.Gateway/CallType.cs
@@ -1,5 +1,7 @@
 namespace NServiceBus.Gateway
 {
+    using System;
+
     /// <summary>
     /// received request type.
     /// </summary>
@@ -12,6 +14,17 @@ namespace NServiceBus.Gateway
         /// <summary>
         /// Request type for Databus properties.
         /// </summary>
-        SingleCallDatabusProperty
+        SingleCallDatabusProperty,
+
+        /// <summary>
+        /// Legacy Ack, these are sent by V3 Gateway and are ignored
+        /// </summary>
+        Ack,
+
+        /// <summary>
+        /// Legacy Submit, this is equivalent to SingleCallSubmit
+        /// </summary>
+        [Obsolete("Legacy use only. Do not use.", false)]
+        Submit = SingleCallSubmit
     }
 }

--- a/src/NServiceBus.Gateway/GatewayHttpListenerInstaller.cs
+++ b/src/NServiceBus.Gateway/GatewayHttpListenerInstaller.cs
@@ -61,7 +61,7 @@ netsh http add urlacl url={1} user=""{0}""", uri, identity);
             }
         }
 
-        static internal void StartNetshProcess(string identity, Uri uri)
+        internal static void StartNetshProcess(string identity, Uri uri)
         {
             var startInfo = new ProcessStartInfo
             {

--- a/src/NServiceBus.Gateway/Receiving/SingleCallChannelReceiver.cs
+++ b/src/NServiceBus.Gateway/Receiving/SingleCallChannelReceiver.cs
@@ -67,6 +67,9 @@
                         case CallType.SingleCallSubmit:
                             HandleSubmit(callInfo);
                             break;
+                        case CallType.Ack:
+                            // Legacy call from V3. Ignore.
+                            break;
                         default:
                             throw new Exception("Unknown call type: " + callInfo.Type);
                     }

--- a/src/NServiceBus.Gateway/Routing/IRouteMessagesToEndpoints.cs
+++ b/src/NServiceBus.Gateway/Routing/IRouteMessagesToEndpoints.cs
@@ -10,8 +10,7 @@ namespace NServiceBus.Gateway.Routing
         /// </summary>
         /// <param name="messageToSend">The message to send.</param>
         /// <returns>The destination address.</returns>
-// ReSharper disable UnusedParameter.Global
+        // ReSharper disable once UnusedParameter.Global
         Address GetDestinationFor(TransportMessage messageToSend);
-// ReSharper restore UnusedParameter.Global
     }
 }

--- a/src/NServiceBus.Gateway/Sending/SingleCallChannelForwarder.cs
+++ b/src/NServiceBus.Gateway/Sending/SingleCallChannelForwarder.cs
@@ -41,12 +41,13 @@
 
         Dictionary<string,string> MapToHeaders(TransportMessage from)
         {
-            var to = new Dictionary<string, string>(StringComparer.CurrentCultureIgnoreCase);
-
-            to[NServiceBus + Id] = from.Id;
-            to[NServiceBus + CorrelationId] = GetCorrelationForBackwardsCompatibility(from);
-            to[NServiceBus + Recoverable] = from.Recoverable.ToString();
-            to[NServiceBus + TimeToBeReceived] = from.TimeToBeReceived.ToString();
+            var to = new Dictionary<string, string>(StringComparer.CurrentCultureIgnoreCase)
+            {
+                [NServiceBus + Id] = from.Id,
+                [NServiceBus + CorrelationId] = GetCorrelationForBackwardsCompatibility(from),
+                [NServiceBus + Recoverable] = from.Recoverable.ToString(),
+                [NServiceBus + TimeToBeReceived] = from.TimeToBeReceived.ToString()
+            };
 
             if (from.ReplyToAddress != null) //Handles SendOnly endpoints, where ReplyToAddress is not set
             {


### PR DESCRIPTION
**DO NOT MERGE - EXPLORATORY ONLY**

Connects to #55

The additional enumeration members allow the gateway to treat a V3 `Submit` as a current version `SingleCallSubmit`, and ignore an `Ack` completely.

I don't know if this will have any other undesirable effects, as I don't fully understand how the change from V3's gateway model to the current evolved.