### PR TITLE
Support for listening to urls with wildcards

### DIFF
--- a/src/NServiceBus.Gateway/GatewayHttpListenerInstaller.cs
+++ b/src/NServiceBus.Gateway/GatewayHttpListenerInstaller.cs
@@ -48,8 +48,8 @@ netsh http add urlacl url={{http://URL:PORT/[PATH/] | https://URL:PORT/[PATH/]}}
             {
                 if (receiveChannel.Type.ToLower() != "http") continue;
 
-                var uri = new Uri(receiveChannel.Address);
-                if (!uri.Scheme.StartsWith("http", StringComparison.InvariantCultureIgnoreCase))
+                var uri = receiveChannel.Address;
+                if(!uri.StartsWith("http", StringComparison.InvariantCultureIgnoreCase))
                 {
                     continue;
                 }
@@ -69,7 +69,7 @@ netsh http add urlacl url={1} user=""{0}""", uri, identity);
             return Task.FromResult(0);
         }
 
-        static void StartNetshProcess(string identity, Uri uri)
+        static void StartNetshProcess(string identity, string uri)
         {
             var startInfo = new ProcessStartInfo
             {


### PR DESCRIPTION
### Problem description

When NSB.Gateway is used in an environment where there's no control over the channel address is possible, at the time when address is registered with URLACL, it must be registered with a wildcard.

### Use case

One of the customers was trying to host the `RemoteSite` equivalent of the [NSB.Gateway sample](https://docs.particular.net/samples/gateway/) in a Service Fabric (SF) sample. Problem with that approach is the URL registered for a channel cannot be in a URI format as below:

```xml
    <Channel Address="http://localhost:25899/RemoteSite/"
             ChannelType="Http"
             Default="true"/>
```

since requests forwarded to nodes could use FQDN or an IP address. Therefore, the proper registration should be 

```xml
    <Channel Address="http://+:25899/RemoteSite/"
             ChannelType="Http"
             Default="true"/>
```

URL with a wildcard fails, due to NSB.Gateway internal usage of `Uri` to parse the schema. This causes NSB.Gateway to fail when a wildcard URL is registered.

### Solution

This PR replaces `Uri` usage with a primitive `string` considering that `Shema` part is still used as a plain string, the `Uri` is not even needed.

This has been confirmed with a customer to work (using PR nuget package).

@Particular/nservicebus-maintainers please review.