### PR TITLE
prevent fody from propagating

### DIFF
--- a/src/NServiceBus.Gateway/NServiceBus.Gateway.csproj
+++ b/src/NServiceBus.Gateway/NServiceBus.Gateway.csproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
-    <PackageReference Include="Obsolete.Fody" Version="4.*" />
-    <PackageReference Include="Fody" Version="2.*" />
+    <PackageReference Include="Obsolete.Fody" Version="4.*" PrivateAssets="All" />
+    <PackageReference Include="Fody" Version="2.*" PrivateAssets="All" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Transactions" />
     <Reference Include="System.Web" />


### PR DESCRIPTION
so the produced nuget will not have a dependency on fody