### PR TITLE
[WIP] Allow configuration of reverse proxy friendly headers

### DIFF
--- a/src/NServiceBus.Gateway.AcceptanceTests/When_sending_with_reverse_proxy_friendly_headers.cs
+++ b/src/NServiceBus.Gateway.AcceptanceTests/When_sending_with_reverse_proxy_friendly_headers.cs
@@ -1,0 +1,117 @@
+﻿namespace NServiceBus.Gateway.AcceptanceTests
+{
+    using System;
+    using System.IO;
+    using System.Net;
+    using System.Security.Cryptography;
+    using System.Text;
+    using System.Threading.Tasks;
+    using System.Web;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+
+    public class When_sending_with_reverse_proxy_friendly_headers : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_process_message()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Headquarters>(b => b.When(bus =>
+                {
+#pragma warning disable DE0003 // API is deprecated
+                    var webRequest = (HttpWebRequest)WebRequest.Create("http://localhost:25898/Headquarters/");
+#pragma warning restore DE0003 // API is deprecated
+                    webRequest.Method = "POST";
+                    webRequest.ContentType = "text/xml; charset=utf-8";
+                    webRequest.UserAgent = "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1)";
+
+                    webRequest.Headers.Add("Content-Encoding", "utf-8");
+                    webRequest.Headers.Add("NServiceBus-CallType", "SingleCallSubmit");
+                    webRequest.Headers.Add("NServiceBus-AutoAck", "true");
+                    webRequest.Headers.Add("MySpecialHeader", "MySpecialValue");
+                    webRequest.Headers.Add("NServiceBus-Id", Guid.NewGuid().ToString("N"));
+
+                    const string message = "<?xml version=\"1.0\" ?><Messages xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns=\"http://tempuri.net/NServiceBus.Gateway.AcceptanceTests\"><MyRequest></MyRequest></Messages>";
+
+                    using (var messagePayload = new MemoryStream(Encoding.UTF8.GetBytes(message)))
+                    {
+                        webRequest.Headers.Add(HttpRequestHeader.ContentMd5, HttpUtility.UrlEncode(Hash(messagePayload)));
+                        webRequest.ContentLength = messagePayload.Length;
+
+                        using (var requestStream = webRequest.GetRequestStream())
+                        {
+                            messagePayload.CopyTo(requestStream);
+                        }
+                    }
+
+                    while (true)
+                    {
+                        try
+                        {
+                            using (var myWebResponse = (HttpWebResponse)webRequest.GetResponse())
+                            {
+                                if (myWebResponse.StatusCode == HttpStatusCode.OK)
+                                {
+                                    break;
+                                }
+                            }
+                        }
+                        catch (WebException)
+                        {
+                        }
+                    }
+                    return Task.FromResult(0);
+                }))
+                .Done(c => c.GotMessage)
+                .Run();
+
+            Assert.IsTrue(context.GotMessage);
+            Assert.AreEqual("MySpecialValue", context.MySpecialHeader);
+        }
+
+        static string Hash(Stream stream)
+        {
+            var position = stream.Position;
+            var hash = MD5.Create().ComputeHash(stream);
+
+            stream.Position = position;
+
+            return Convert.ToBase64String(hash);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool GotMessage { get; set; }
+
+            public string MySpecialHeader { get; set; }
+        }
+
+        public class Headquarters : EndpointConfigurationBuilder
+        {
+            public Headquarters()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.Gateway().AddReceiveChannel("http://localhost:25898/Headquarters/");
+                })
+                .IncludeType<MyRequest>();
+            }
+
+            public class MyResponseHandler : IHandleMessages<MyRequest>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(MyRequest response, IMessageHandlerContext context)
+                {
+                    Context.MySpecialHeader = context.MessageHeaders["MySpecialHeader"];
+                    Context.GotMessage = true;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+        public class MyRequest : IMessage
+        {
+        }
+
+    }
+}

--- a/src/NServiceBus.Gateway.AcceptanceTests/When_sending_with_reverse_proxy_friendly_headers.cs
+++ b/src/NServiceBus.Gateway.AcceptanceTests/When_sending_with_reverse_proxy_friendly_headers.cs
@@ -109,9 +109,5 @@
                 }
             }
         }
-        public class MyRequest : IMessage
-        {
-        }
-
     }
 }

--- a/src/NServiceBus.Gateway.Tests/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Gateway.Tests/APIApprovals.Approve.approved.txt
@@ -62,6 +62,8 @@ namespace NServiceBus.Config
         public string Key { get; set; }
         [System.Configuration.ConfigurationPropertyAttribute("LegacyMode", DefaultValue=true, IsKey=false, IsRequired=false)]
         public bool LegacyMode { get; set; }
+        [System.Configuration.ConfigurationPropertyAttribute("UsesReverseProxy", DefaultValue=false, IsKey=false, IsRequired=false)]
+        public bool UsesReverseProxy { get; set; }
     }
 }
 namespace NServiceBus.Features
@@ -130,6 +132,7 @@ namespace NServiceBus.Gateway.Routing
         public NServiceBus.Gateway.Channels.Channel Channel { get; set; }
         public string Key { get; set; }
         public bool LegacyMode { get; set; }
+        public bool UsesReverseProxy { get; set; }
     }
 }
 namespace NServiceBus
@@ -141,7 +144,7 @@ namespace NServiceBus
     public class GatewaySettings
     {
         public void AddReceiveChannel(string address, string type = "http", int maxConcurrency = 1, bool isDefault = False) { }
-        public void AddSite(string siteKey, string address, string type = "http", bool legacyMode = False) { }
+        public void AddSite(string siteKey, string address, string type = "http", bool legacyMode = False, bool usesReverseProxy = False) { }
         public void ChannelFactories(System.Func<string, NServiceBus.Gateway.IChannelSender> senderFactory, System.Func<string, NServiceBus.Gateway.IChannelReceiver> receiverFactory) { }
         public void CustomRetryPolicy(System.Func<NServiceBus.Transport.IncomingMessage, System.Exception, int, System.TimeSpan> customRetryPolicy) { }
         public void DisableRetries() { }

--- a/src/NServiceBus.Gateway.Tests/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Gateway.Tests/APIApprovals.Approve.approved.txt
@@ -62,8 +62,6 @@ namespace NServiceBus.Config
         public string Key { get; set; }
         [System.Configuration.ConfigurationPropertyAttribute("LegacyMode", DefaultValue=true, IsKey=false, IsRequired=false)]
         public bool LegacyMode { get; set; }
-        [System.Configuration.ConfigurationPropertyAttribute("UsesReverseProxy", DefaultValue=false, IsKey=false, IsRequired=false)]
-        public bool UsesReverseProxy { get; set; }
     }
 }
 namespace NServiceBus.Features

--- a/src/NServiceBus.Gateway/Channels/Http/HttpChannelReceiver.cs
+++ b/src/NServiceBus.Gateway/Channels/Http/HttpChannelReceiver.cs
@@ -176,7 +176,13 @@ namespace NServiceBus.Gateway.Channels.Http
 
             foreach (string header in context.Request.Headers.Keys)
             {
-                headers.Add(HttpUtility.UrlDecode(header), HttpUtility.UrlDecode(context.Request.Headers[header]));
+                var key = HttpUtility.UrlDecode(header);
+                if (key.Contains("NServiceBus-"))
+                {
+                    key = key.Replace("-", ".");
+                }
+
+                headers.Add(key, HttpUtility.UrlDecode(context.Request.Headers[header]));
             }
 
             foreach (string header in context.Request.QueryString.Keys)

--- a/src/NServiceBus.Gateway/Config/SiteConfig.cs
+++ b/src/NServiceBus.Gateway/Config/SiteConfig.cs
@@ -72,22 +72,6 @@ namespace NServiceBus.Config
                 this["LegacyMode"] = value;
             }
         }
-
-        /// <summary>
-        /// Is the site behind a reverse proxy 
-        /// </summary>
-        [ConfigurationProperty("UsesReverseProxy", IsRequired = false, DefaultValue = false, IsKey = false)]
-        public bool UsesReverseProxy
-        {
-            get
-            {
-                return (bool) this["UsesReverseProxy"]; 
-            }
-            set
-            {
-                this["UsesReverseProxy"] = value;
-            }
-        }
     }
 }
 #endif

--- a/src/NServiceBus.Gateway/Config/SiteConfig.cs
+++ b/src/NServiceBus.Gateway/Config/SiteConfig.cs
@@ -72,6 +72,22 @@ namespace NServiceBus.Config
                 this["LegacyMode"] = value;
             }
         }
+
+        /// <summary>
+        /// Is the site behind a reverse proxy 
+        /// </summary>
+        [ConfigurationProperty("UsesReverseProxy", IsRequired = false, DefaultValue = false, IsKey = false)]
+        public bool UsesReverseProxy
+        {
+            get
+            {
+                return (bool) this["UsesReverseProxy"]; 
+            }
+            set
+            {
+                this["UsesReverseProxy"] = value;
+            }
+        }
     }
 }
 #endif

--- a/src/NServiceBus.Gateway/GatewayExtensions.cs
+++ b/src/NServiceBus.Gateway/GatewayExtensions.cs
@@ -29,5 +29,19 @@
 
             return legacyMode;
         }
+
+        /// <summary>
+        ///     encode headers for reverse proxy
+        /// </summary>
+        public static IDictionary<string, string> EncodeHeadersForReverseProxy(this IDictionary<string, string> headers)
+        {
+            var encodedHeaders = new Dictionary<string, string>();
+            foreach (var header in headers)
+            {
+                encodedHeaders.Add(header.Key.Replace(".","-"),header.Value);
+            }
+
+            return encodedHeaders;
+        }
     }
 }

--- a/src/NServiceBus.Gateway/Routing/Site.cs
+++ b/src/NServiceBus.Gateway/Routing/Site.cs
@@ -21,5 +21,10 @@ namespace NServiceBus.Gateway.Routing
         /// <code>true</code> to set the forwarding mode for this site to use legacy mode.
         /// </summary>
         public bool LegacyMode { get; set; }
+
+        /// <summary>
+        /// <code>true</code> to use reverse proxy friendly headers.
+        /// </summary>
+        public bool UsesReverseProxy { get; set; }
     }
 }

--- a/src/NServiceBus.Gateway/Sending/SingleCallChannelForwarder.cs
+++ b/src/NServiceBus.Gateway/Sending/SingleCallChannelForwarder.cs
@@ -88,6 +88,11 @@
 
             Logger.DebugFormat("Sending message - {0} to: {1}", callType, targetSite.Channel.Address);
 
+            if (targetSite.UsesReverseProxy)
+            {
+                headers = headers.EncodeHeadersForReverseProxy();
+            }
+
             await channelSender.Send(targetSite.Channel.Address, headers, data).ConfigureAwait(false);
         }
 

--- a/src/NServiceBus.Gateway/Settings/GatewaySettings.cs
+++ b/src/NServiceBus.Gateway/Settings/GatewaySettings.cs
@@ -89,7 +89,7 @@
             Guard.AgainstNullAndEmpty(nameof(siteKey), siteKey);
             Guard.AgainstNullAndEmpty(nameof(address), address);
             Guard.AgainstNullAndEmpty(nameof(type), type);
-            
+
             var site = new Site
             {
                 Channel = new Channel

--- a/src/NServiceBus.Gateway/Settings/GatewaySettings.cs
+++ b/src/NServiceBus.Gateway/Settings/GatewaySettings.cs
@@ -83,12 +83,13 @@
         /// <param name="address">The channel address.</param>
         /// <param name="type">The channel type. Default is `http`.</param>
         /// <param name="legacyMode">Pass `true` to set the forwarding mode for this site to legacy mode.</param>
-        public void AddSite(string siteKey, string address, string type = "http", bool legacyMode = false)
+        /// <param name="usesReverseProxy">Pass `true` if site is behind a reverse proxy that doesn't like headers with periods in them.</param>
+        public void AddSite(string siteKey, string address, string type = "http", bool legacyMode = false, bool usesReverseProxy = false)
         {
             Guard.AgainstNullAndEmpty(nameof(siteKey), siteKey);
             Guard.AgainstNullAndEmpty(nameof(address), address);
             Guard.AgainstNullAndEmpty(nameof(type), type);
-
+            
             var site = new Site
             {
                 Channel = new Channel
@@ -97,7 +98,8 @@
                     Type = type
                 },
                 Key = siteKey,
-                LegacyMode = legacyMode
+                LegacyMode = legacyMode,
+                UsesReverseProxy = usesReverseProxy
             };
 
             if (settings.TryGet(out List<Site> sites))


### PR DESCRIPTION
Added the ability to configure remote sites as being behind reverse proxies (such as nginx and cloudflare) that don't allow headers with periods in them. I appreciate there might not be too many people who ever need to do this so I've tried to make it as unobtrusive as possible. fixes #84