### PR TITLE
Add gateway storage acceptance test package

### DIFF
--- a/src/GitVersionWorkaround.targets
+++ b/src/GitVersionWorkaround.targets
@@ -1,0 +1,18 @@
+<Project>
+
+  <!-- Workaround because of https://github.com/NuGet/Home/issues/4790 -->
+  <PropertyGroup>
+    <GitVersionTaskVersion>4.0.0-beta0012</GitVersionTaskVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GitVersionTask" Version="$(GitVersionTaskVersion)" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ImportGroup Condition="'$(ExcludeRestorePackageImports)' == 'true' And '$(MSBuildRuntimeType)' != 'Core'">
+    <Import Project="$(UserProfile)\.nuget\packages\gitversiontask\$(GitVersionTaskVersion)\buildMultiTargeting\GitVersionTask.targets" Condition="Exists('$(UserProfile)\.nuget\packages\gitversiontask\$(GitVersionTaskVersion)\buildMultiTargeting\GitVersionTask.targets')" />
+  </ImportGroup>
+  <Target Name="FixUpVersion" BeforeTargets="_GenerateRestoreProjectSpec" DependsOnTargets="GetVersion" Condition="'$(GitVersion_Task_targets_Imported)' == 'True'" />
+  <!-- End Workaround -->
+
+</Project>

--- a/src/NServiceBus.Gateway.AcceptanceTests/DefaultServerWithNoStorage.cs
+++ b/src/NServiceBus.Gateway.AcceptanceTests/DefaultServerWithNoStorage.cs
@@ -21,6 +21,8 @@
 
             var storageDir = Path.Combine(NServiceBusAcceptanceTest.StorageRootDir, TestContext.CurrentContext.Test.ID);
 
+            endpointConfiguration.EnableInstallers();
+
             endpointConfiguration.UseTransport<LearningTransport>()
                 .StorageDirectory(storageDir);
 

--- a/src/NServiceBus.Gateway.AcceptanceTests/GatewayEndpoint.cs
+++ b/src/NServiceBus.Gateway.AcceptanceTests/GatewayEndpoint.cs
@@ -1,8 +1,8 @@
 ﻿namespace NServiceBus.Gateway.AcceptanceTests
 {
-    public class DefaultServer : DefaultServerWithNoStorage
+    public class GatewayEndpoint : GatewayEndpointWithNoStorage
     {
-        public DefaultServer()
+        public GatewayEndpoint()
         {
             ConfigureStorage = true;
         }

--- a/src/NServiceBus.Gateway.AcceptanceTests/GatewayEndpointWithNoStorage.cs
+++ b/src/NServiceBus.Gateway.AcceptanceTests/GatewayEndpointWithNoStorage.cs
@@ -7,7 +7,7 @@
     using AcceptanceTesting.Support;
     using NUnit.Framework;
 
-    public class DefaultServerWithNoStorage : IEndpointSetupTemplate
+    public class GatewayEndpointWithNoStorage : IEndpointSetupTemplate
     {
         public async Task<EndpointConfiguration> GetConfiguration(RunDescriptor runDescriptor, EndpointCustomizationConfiguration endpointCustomizationConfiguration, Action<EndpointConfiguration> configurationBuilderCustomization)
         {

--- a/src/NServiceBus.Gateway.AcceptanceTests/GatewayTestSuiteConstraints.cs
+++ b/src/NServiceBus.Gateway.AcceptanceTests/GatewayTestSuiteConstraints.cs
@@ -1,22 +1,7 @@
 ﻿namespace NServiceBus.Gateway.AcceptanceTests
 {
-    using System.Threading.Tasks;
-    using AcceptanceTesting.Support;
-
     public partial class GatewayTestSuiteConstraints : IGatewayTestSuiteConstraints
     {
         public static GatewayTestSuiteConstraints Current = new GatewayTestSuiteConstraints();
-    }
-
-    public interface IGatewayTestSuiteConstraints
-    {
-        IConfigureGatewayPersitenceExecution CreatePersistenceConfiguration();
-    }
-
-    public interface IConfigureGatewayPersitenceExecution
-    {
-        Task Configure(string endpointName, EndpointConfiguration configuration, RunSettings settings);
-
-        Task Cleanup();
     }
 }

--- a/src/NServiceBus.Gateway.AcceptanceTests/GatewayTestSuiteConstraints.cs
+++ b/src/NServiceBus.Gateway.AcceptanceTests/GatewayTestSuiteConstraints.cs
@@ -1,0 +1,22 @@
+﻿namespace NServiceBus.Gateway.AcceptanceTests
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting.Support;
+
+    public partial class GatewayTestSuiteConstraints : IGatewayTestSuiteConstraints
+    {
+        public static GatewayTestSuiteConstraints Current = new GatewayTestSuiteConstraints();
+    }
+
+    public interface IGatewayTestSuiteConstraints
+    {
+        IConfigureGatewayPersitenceExecution CreatePersistenceConfiguration();
+    }
+
+    public interface IConfigureGatewayPersitenceExecution
+    {
+        Task Configure(string endpointName, EndpointConfiguration configuration, RunSettings settings);
+
+        Task Cleanup();
+    }
+}

--- a/src/NServiceBus.Gateway.AcceptanceTests/IConfigureGatewayPersitenceExecution.cs
+++ b/src/NServiceBus.Gateway.AcceptanceTests/IConfigureGatewayPersitenceExecution.cs
@@ -1,0 +1,12 @@
+﻿namespace NServiceBus.Gateway.AcceptanceTests
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting.Support;
+
+    public interface IConfigureGatewayPersitenceExecution
+    {
+        Task Configure(string endpointName, EndpointConfiguration configuration, RunSettings settings);
+
+        Task Cleanup();
+    }
+}

--- a/src/NServiceBus.Gateway.AcceptanceTests/IGatewayTestSuiteConstraints.cs
+++ b/src/NServiceBus.Gateway.AcceptanceTests/IGatewayTestSuiteConstraints.cs
@@ -1,0 +1,7 @@
+﻿namespace NServiceBus.Gateway.AcceptanceTests
+{
+    public interface IGatewayTestSuiteConstraints
+    {
+        IConfigureGatewayPersitenceExecution CreatePersistenceConfiguration();
+    }
+}

--- a/src/NServiceBus.Gateway.AcceptanceTests/InMemoryPersistenceConfiguration.cs
+++ b/src/NServiceBus.Gateway.AcceptanceTests/InMemoryPersistenceConfiguration.cs
@@ -1,0 +1,21 @@
+﻿namespace NServiceBus.Gateway.AcceptanceTests
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting.Support;
+
+    public class InMemoryPersistenceConfiguration : IConfigureGatewayPersitenceExecution
+    {
+        public Task Configure(string endpointName, EndpointConfiguration configuration, RunSettings settings)
+        {
+            configuration.UsePersistence<InMemoryPersistence, StorageType.GatewayDeduplication>();
+
+            return Task.FromResult(0);
+        }
+
+        public Task Cleanup()
+        {
+            //no-op
+            return Task.FromResult(0);
+        }
+    }
+}

--- a/src/NServiceBus.Gateway.AcceptanceTests/InMemoryPersistenceConfiguration.cs
+++ b/src/NServiceBus.Gateway.AcceptanceTests/InMemoryPersistenceConfiguration.cs
@@ -3,6 +3,7 @@
     using System.Threading.Tasks;
     using AcceptanceTesting.Support;
 
+    //we don't ship this class in the package
     public class InMemoryPersistenceConfiguration : IConfigureGatewayPersitenceExecution
     {
         public Task Configure(string endpointName, EndpointConfiguration configuration, RunSettings settings)

--- a/src/NServiceBus.Gateway.AcceptanceTests/InMemoryTestSuiteConstaints.cs
+++ b/src/NServiceBus.Gateway.AcceptanceTests/InMemoryTestSuiteConstaints.cs
@@ -1,9 +1,8 @@
 ﻿namespace NServiceBus.Gateway.AcceptanceTests
 {
-    //we don't ship this class in the package
+    //we don't ship this class in the source package since downstreams should provide their own storage config.
     public partial class GatewayTestSuiteConstraints
     {
-        //we don't ship this class in the package
         public IConfigureGatewayPersitenceExecution CreatePersistenceConfiguration()
         {
             return new InMemoryPersistenceConfiguration();

--- a/src/NServiceBus.Gateway.AcceptanceTests/InMemoryTestSuiteConstaints.cs
+++ b/src/NServiceBus.Gateway.AcceptanceTests/InMemoryTestSuiteConstaints.cs
@@ -1,0 +1,12 @@
+﻿namespace NServiceBus.Gateway.AcceptanceTests
+{
+    //we don't ship this class in the package
+    public partial class GatewayTestSuiteConstraints
+    {
+        //we don't ship this class in the package
+        public IConfigureGatewayPersitenceExecution CreatePersistenceConfiguration()
+        {
+            return new InMemoryPersistenceConfiguration();
+        }
+    }
+}

--- a/src/NServiceBus.Gateway.AcceptanceTests/NServiceBus.Gateway.AcceptanceTests.csproj
+++ b/src/NServiceBus.Gateway.AcceptanceTests/NServiceBus.Gateway.AcceptanceTests.csproj
@@ -41,4 +41,9 @@
     <_PackageFiles Remove="**\InMemoryTestSuiteConstaints.cs" />
   </ItemGroup>
 
+  <ItemGroup>
+    <_PackageFiles Remove="GatewayEndpoint.cs" />
+    <_PackageFiles Remove="GatewayEndpointWithNoStorage.cs" />
+  </ItemGroup>
+
 </Project>

--- a/src/NServiceBus.Gateway.AcceptanceTests/NServiceBus.Gateway.AcceptanceTests.csproj
+++ b/src/NServiceBus.Gateway.AcceptanceTests/NServiceBus.Gateway.AcceptanceTests.csproj
@@ -41,9 +41,4 @@
     <_PackageFiles Remove="**\InMemoryTestSuiteConstaints.cs" />
   </ItemGroup>
 
-  <ItemGroup>
-    <_PackageFiles Remove="GatewayEndpoint.cs" />
-    <_PackageFiles Remove="GatewayEndpointWithNoStorage.cs" />
-  </ItemGroup>
-
 </Project>

--- a/src/NServiceBus.Gateway.AcceptanceTests/NServiceBus.Gateway.AcceptanceTests.csproj
+++ b/src/NServiceBus.Gateway.AcceptanceTests/NServiceBus.Gateway.AcceptanceTests.csproj
@@ -42,12 +42,4 @@
     <_PackageFiles Remove="**\InMemoryTestSuiteConstaints.cs" />
   </ItemGroup>
 
-  <ItemGroup>
-    <_PackageFiles Remove="GatewayTestSuiteConstraints.cs" />
-    <_PackageFiles Remove="IConfigureGatewayPersitenceExecution.cs" />
-    <_PackageFiles Remove="IGatewayTestSuiteConstraints.cs" />
-    <_PackageFiles Remove="InMemoryPersistenceConfiguration.cs" />
-    <_PackageFiles Remove="InMemoryTestSuiteConstaints.cs" />
-  </ItemGroup>
-
 </Project>

--- a/src/NServiceBus.Gateway.AcceptanceTests/NServiceBus.Gateway.AcceptanceTests.csproj
+++ b/src/NServiceBus.Gateway.AcceptanceTests/NServiceBus.Gateway.AcceptanceTests.csproj
@@ -20,7 +20,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" PrivateAssets="All" />
-    <PackageReference Include="NUnit" Version="3.7.1" PrivateAssets="All" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="0.1.0" PrivateAssets="All" />
   </ItemGroup>

--- a/src/NServiceBus.Gateway.AcceptanceTests/NServiceBus.Gateway.AcceptanceTests.csproj
+++ b/src/NServiceBus.Gateway.AcceptanceTests/NServiceBus.Gateway.AcceptanceTests.csproj
@@ -14,11 +14,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="7.0.0-beta0012" />
-    <PackageReference Include="NServiceBus.Callbacks" Version="3.0.0-beta0003" />
-    <PackageReference Include="NUnit" Version="3.7.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
+    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="[7.0.0-beta0012, 8.0.0)" />
+    <PackageReference Include="NServiceBus.Callbacks" Version="[3.0.0-beta0003, 4.0.0)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" PrivateAssets="All" />
+    <PackageReference Include="NUnit" Version="3.7.1" PrivateAssets="All" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="0.1.0" PrivateAssets="All" />
   </ItemGroup>
 
@@ -32,10 +35,9 @@
   <ItemGroup>
     <_PackageFiles Include="**\*.cs">
       <BuildAction>Compile</BuildAction>
-      <PackagePath>content\App_Packages\NSB.GW.AcceptanceTests\;contentFiles\cs\any\NSB.GW.AcceptanceTests\</PackagePath>
+      <PackagePath>content\App_Packages\NSB.Gateway.AcceptanceTests\;contentFiles\cs\any\NSB.Gateway.AcceptanceTests\</PackagePath>
     </_PackageFiles>
-    <_PackageFiles Remove="**\obj\**\*.cs" />    
-    <_PackageFiles Remove="AssemblyInfo.cs" />
+    <_PackageFiles Remove="**\obj\**\*.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.Gateway.AcceptanceTests/NServiceBus.Gateway.AcceptanceTests.csproj
+++ b/src/NServiceBus.Gateway.AcceptanceTests/NServiceBus.Gateway.AcceptanceTests.csproj
@@ -38,6 +38,16 @@
       <PackagePath>content\App_Packages\NSB.Gateway.AcceptanceTests\;contentFiles\cs\any\NSB.Gateway.AcceptanceTests\</PackagePath>
     </_PackageFiles>
     <_PackageFiles Remove="**\obj\**\*.cs" />
+    <_PackageFiles Remove="**\InMemoryPersistenceConfiguration.cs" />
+    <_PackageFiles Remove="**\InMemoryTestSuiteConstaints.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <_PackageFiles Remove="GatewayTestSuiteConstraints.cs" />
+    <_PackageFiles Remove="IConfigureGatewayPersitenceExecution.cs" />
+    <_PackageFiles Remove="IGatewayTestSuiteConstraints.cs" />
+    <_PackageFiles Remove="InMemoryPersistenceConfiguration.cs" />
+    <_PackageFiles Remove="InMemoryTestSuiteConstaints.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.Gateway.AcceptanceTests/NServiceBus.Gateway.AcceptanceTests.csproj
+++ b/src/NServiceBus.Gateway.AcceptanceTests/NServiceBus.Gateway.AcceptanceTests.csproj
@@ -19,6 +19,23 @@
     <PackageReference Include="NServiceBus.Callbacks" Version="3.0.0-beta0003" />
     <PackageReference Include="NUnit" Version="3.7.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
+    <PackageReference Include="Particular.Packaging" Version="0.1.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <PackageId>NServiceBus.Gateway.AcceptanceTests.Sources</PackageId>
+    <Description>Acceptance tests for NServiceBus gateway functionality</Description>
+    <IsPackable>true</IsPackable>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <_PackageFiles Include="**\*.cs">
+      <BuildAction>Compile</BuildAction>
+      <PackagePath>content\App_Packages\NSB.GW.AcceptanceTests\;contentFiles\cs\any\NSB.GW.AcceptanceTests\</PackagePath>
+    </_PackageFiles>
+    <_PackageFiles Remove="**\obj\**\*.cs" />    
+    <_PackageFiles Remove="AssemblyInfo.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.Gateway.AcceptanceTests/When_a_persistence_does_not_support_gateway_dedup.cs
+++ b/src/NServiceBus.Gateway.AcceptanceTests/When_a_persistence_does_not_support_gateway_dedup.cs
@@ -21,7 +21,7 @@
         {
             public Endpoint()
             {
-                EndpointSetup<DefaultServerWithNoStorage>(c =>
+                EndpointSetup<GatewayEndpointWithNoStorage>(c =>
                 {
                     c.Gateway().AddReceiveChannel("http://localhost:25898/SomeSite/");
                 });

--- a/src/NServiceBus.Gateway.AcceptanceTests/When_doing_request_reply.cs
+++ b/src/NServiceBus.Gateway.AcceptanceTests/When_doing_request_reply.cs
@@ -36,7 +36,7 @@
         {
             public SiteA()
             {
-                EndpointSetup<DefaultServer>(c =>
+                EndpointSetup<GatewayEndpoint>(c =>
                 {
                     c.MakeInstanceUniquelyAddressable("1");
                     c.EnableCallbacks();
@@ -53,7 +53,7 @@
         {
             public SiteB()
             {
-                EndpointSetup<DefaultServer>(c =>
+                EndpointSetup<GatewayEndpoint>(c =>
                 {
                     c.EnableCallbacks(makesRequests: false);
                     c.Gateway().AddReceiveChannel("http://localhost:25699/SiteB/");

--- a/src/NServiceBus.Gateway.AcceptanceTests/When_doing_request_response_between_sites.cs
+++ b/src/NServiceBus.Gateway.AcceptanceTests/When_doing_request_response_between_sites.cs
@@ -36,7 +36,7 @@
         {
             public SiteA()
             {
-                EndpointSetup<DefaultServer>(c =>
+                EndpointSetup<GatewayEndpoint>(c =>
                 {
                     c.MakeInstanceUniquelyAddressable("1");
                     c.EnableCallbacks();
@@ -53,7 +53,7 @@
         {
             public SiteB()
             {
-                EndpointSetup<DefaultServer>(c =>
+                EndpointSetup<GatewayEndpoint>(c =>
                 {
                     c.EnableCallbacks(makesRequests: false);
                     c.Gateway().AddReceiveChannel("http://localhost:25799/SiteB/");

--- a/src/NServiceBus.Gateway.AcceptanceTests/When_doing_request_response_with_databus_between_sites.cs
+++ b/src/NServiceBus.Gateway.AcceptanceTests/When_doing_request_response_with_databus_between_sites.cs
@@ -51,7 +51,7 @@
         {
             public SiteA()
             {
-                EndpointSetup<DefaultServer>(c =>
+                EndpointSetup<GatewayEndpoint>(c =>
                 {
                     c.UseDataBus<FileShareDataBus>().BasePath(@".\databus\siteA");
                     c.MakeInstanceUniquelyAddressable("1");
@@ -85,7 +85,7 @@
         {
             public SiteB()
             {
-                EndpointSetup<DefaultServer>(c =>
+                EndpointSetup<GatewayEndpoint>(c =>
                 {
                     c.UseDataBus<FileShareDataBus>().BasePath(@".\databus\siteB");
                     c.EnableCallbacks(makesRequests: false);

--- a/src/NServiceBus.Gateway.AcceptanceTests/When_listening_on_wildcard_uri.cs
+++ b/src/NServiceBus.Gateway.AcceptanceTests/When_listening_on_wildcard_uri.cs
@@ -21,7 +21,7 @@
         {
             public EndpointWithWildCardUriAsDefault()
             {
-                EndpointSetup<DefaultServer>(c =>
+                EndpointSetup<GatewayEndpoint>(c =>
                 {
                     var gatewaySettings = c.Gateway();
 

--- a/src/NServiceBus.Gateway.AcceptanceTests/When_sending_a_message_to_another_site.cs
+++ b/src/NServiceBus.Gateway.AcceptanceTests/When_sending_a_message_to_another_site.cs
@@ -30,7 +30,7 @@
         {
             public Headquarters()
             {
-                EndpointSetup<DefaultServer>(c =>
+                EndpointSetup<GatewayEndpoint>(c =>
                 {
                     var gatewaySettings = c.Gateway();
 
@@ -55,7 +55,7 @@
         {
             public SiteA()
             {
-                EndpointSetup<DefaultServer>(c =>
+                EndpointSetup<GatewayEndpoint>(c =>
                 {
                     c.Gateway().AddReceiveChannel("http://localhost:25999/SiteA/");
                 });

--- a/src/NServiceBus.Gateway.AcceptanceTests/When_sending_a_message_via_the_gateway.cs
+++ b/src/NServiceBus.Gateway.AcceptanceTests/When_sending_a_message_via_the_gateway.cs
@@ -90,7 +90,7 @@
         {
             public Headquarters()
             {
-                EndpointSetup<DefaultServer>(c =>
+                EndpointSetup<GatewayEndpoint>(c =>
                 {
                     c.Gateway().AddReceiveChannel("http://localhost:25898/Headquarters/");
                 })

--- a/src/NServiceBus.Gateway.AcceptanceTests/When_sending_fails_with_retries.cs
+++ b/src/NServiceBus.Gateway.AcceptanceTests/When_sending_fails_with_retries.cs
@@ -73,7 +73,7 @@
         {
             public Headquarters()
             {
-                EndpointSetup<DefaultServer>(c =>
+                EndpointSetup<GatewayEndpoint>(c =>
                 {
                     var gatewaySettings = c.Gateway();
 
@@ -94,7 +94,7 @@
         {
             public ErrorSpy()
             {
-                EndpointSetup<DefaultServer>();
+                EndpointSetup<GatewayEndpoint>();
             }
 
             class ErrorMessageHandler : IHandleMessages<AnyMessage>

--- a/src/NServiceBus.Gateway.AcceptanceTests/When_sending_fails_without_retries.cs
+++ b/src/NServiceBus.Gateway.AcceptanceTests/When_sending_fails_without_retries.cs
@@ -42,7 +42,7 @@
         {
             public Headquarters()
             {
-                EndpointSetup<DefaultServer>(c =>
+                EndpointSetup<GatewayEndpoint>(c =>
                 {
                     c.SendFailedMessagesTo(Conventions.EndpointNamingConvention(typeof(ErrorSpy)));
 
@@ -64,7 +64,7 @@
         {
             public ErrorSpy()
             {
-                EndpointSetup<DefaultServer>();
+                EndpointSetup<GatewayEndpoint>();
             }
 
             class ErrorMessageHandler : IHandleMessages<AnyMessage>

--- a/src/NServiceBus.Gateway/Gateway.cs
+++ b/src/NServiceBus.Gateway/Gateway.cs
@@ -38,8 +38,8 @@
         {
             DependsOn("NServiceBus.Features.DelayedDeliveryFeature");
             Defaults(s => s.SetDefault("Gateway.Retries.RetryPolicy", DefaultRetryPolicy.BuildWithDefaults()));
-            
-            // since the installers are registered even if the feature isn't enabled we need to make 
+
+            // since the installers are registered even if the feature isn't enabled we need to make
             // this a no-op if the installer runs without the feature enabled
             Defaults(c => c.Set<InstallerSettings>(new InstallerSettings()));
         }

--- a/src/NServiceBus.Gateway/Installer/GatewayHttpListenerInstaller.cs
+++ b/src/NServiceBus.Gateway/Installer/GatewayHttpListenerInstaller.cs
@@ -16,7 +16,11 @@ namespace NServiceBus.Installation
 
         public GatewayHttpListenerInstaller(ReadOnlySettings settings)
         {
-            var installerSettings = settings.Get<InstallerSettings>();
+            if (!settings.TryGet<InstallerSettings>(out var installerSettings))
+            {
+                return;
+            }
+
             channelManager = installerSettings.ChannelManager;
             enabled = installerSettings.Enabled;
         }

--- a/src/NServiceBus.Gateway/NServiceBus.Gateway.csproj
+++ b/src/NServiceBus.Gateway/NServiceBus.Gateway.csproj
@@ -24,4 +24,6 @@
     <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.5.0" />
   </ItemGroup>
 
+  <Import Project="../GitVersionWorkaround.targets" />
+
 </Project>


### PR DESCRIPTION
To allow downstream persisters to test the gateway storage

* To enable downstreams to setup things like tables etc the acceptance tests had to enable the installers. This highlighted a bug where the GW code assumed the feature to always be enabled. This is no longer true and since[ the core will only set defaults for enabled features](https://github.com/Particular/NServiceBus/blob/develop/src/NServiceBus.Core/Features/FeatureActivator.cs#L54) this turned out to be a bug since installers always run no matter what. This bug is fixed in this PR. The ex was `System.Collections.Generic.KeyNotFoundException : The given key (NServiceBus.Gateway.Installer.InstallerSettings) was not present in the dictionary.`