### PR TITLE
Update GitVersionWorkaround.targets for VS 2017 15.6

### DIFF
--- a/src/GitVersionWorkaround.targets
+++ b/src/GitVersionWorkaround.targets
@@ -1,18 +1,9 @@
 <Project>
 
-  <!-- Workaround because of https://github.com/NuGet/Home/issues/4790 -->
+  <!-- Workaround because https://github.com/GitTools/GitVersion/pull/1351 hasn't been released yet -->
   <PropertyGroup>
-    <GitVersionTaskVersion>4.0.0-beta0012</GitVersionTaskVersion>
+    <GetPackageVersionDependsOn>$(GetPackageVersionDependsOn);GetVersion</GetPackageVersionDependsOn>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="GitVersionTask" Version="$(GitVersionTaskVersion)" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ImportGroup Condition="'$(ExcludeRestorePackageImports)' == 'true' And '$(MSBuildRuntimeType)' != 'Core'">
-    <Import Project="$(UserProfile)\.nuget\packages\gitversiontask\$(GitVersionTaskVersion)\buildMultiTargeting\GitVersionTask.targets" Condition="Exists('$(UserProfile)\.nuget\packages\gitversiontask\$(GitVersionTaskVersion)\buildMultiTargeting\GitVersionTask.targets')" />
-  </ImportGroup>
-  <Target Name="FixUpVersion" BeforeTargets="_GenerateRestoreProjectSpec" DependsOnTargets="GetVersion" Condition="'$(GitVersion_Task_targets_Imported)' == 'True'" />
   <!-- End Workaround -->
 
 </Project>


### PR DESCRIPTION
VS 2017 15.6 includes a fix to allow GitVersion to be invoked at the correct time to ensure that package dependencies created from project references have the correct version.

However, the fix requires that GitVersion make a change to work with the new feature added in 15.6. That changed has been [merged,](https://github.com/GitTools/GitVersion/pull/1351) but there still isn't an updated release that includes it.

A side effect of the 15.6 fix is that the previous workaround is now no longer works. While we're waiting for GitVersion, we need to update the workaround so that we can still get correct packages.
