### PR TITLE
Session based API

### DIFF
--- a/src/NServiceBus.Gateway.Tests/ApprovalFiles/APIApprovals.Approve.netframework.approved.txt
+++ b/src/NServiceBus.Gateway.Tests/ApprovalFiles/APIApprovals.Approve.netframework.approved.txt
@@ -112,7 +112,7 @@ namespace NServiceBus.Gateway
     {
         System.Threading.Tasks.Task Send(string remoteAddress, System.Collections.Generic.IDictionary<string, string> headers, System.IO.Stream data);
     }
-    public interface IDuplicationCheckSession : System.IDisposable
+    public interface IDeduplicationSession : System.IDisposable
     {
         bool IsDuplicate { get; }
         System.Threading.Tasks.Task MarkAsDispatched();
@@ -120,7 +120,7 @@ namespace NServiceBus.Gateway
     public interface IGatewayDeduplicationStorage
     {
         bool SupportsDistributedTransactions { get; }
-        System.Threading.Tasks.Task<NServiceBus.Gateway.IDuplicationCheckSession> CheckForDuplicate(string messageId, NServiceBus.Extensibility.ContextBag context);
+        System.Threading.Tasks.Task<NServiceBus.Gateway.IDeduplicationSession> CheckForDuplicate(string messageId, NServiceBus.Extensibility.ContextBag context);
     }
     public class InMemoryDeduplicationConfiguration : NServiceBus.Gateway.GatewayDeduplicationConfiguration
     {

--- a/src/NServiceBus.Gateway.Tests/ApprovalFiles/APIApprovals.Approve.netframework.approved.txt
+++ b/src/NServiceBus.Gateway.Tests/ApprovalFiles/APIApprovals.Approve.netframework.approved.txt
@@ -112,11 +112,15 @@ namespace NServiceBus.Gateway
     {
         System.Threading.Tasks.Task Send(string remoteAddress, System.Collections.Generic.IDictionary<string, string> headers, System.IO.Stream data);
     }
+    public interface IDuplicationCheckSession : System.IDisposable
+    {
+        bool IsDuplicate { get; }
+        System.Threading.Tasks.Task MarkAsDispatched();
+    }
     public interface IGatewayDeduplicationStorage
     {
         bool SupportsDistributedTransactions { get; }
-        System.Threading.Tasks.Task<bool> IsDuplicate(string messageId, NServiceBus.Extensibility.ContextBag context);
-        System.Threading.Tasks.Task MarkAsDispatched(string messageId, NServiceBus.Extensibility.ContextBag context);
+        System.Threading.Tasks.Task<NServiceBus.Gateway.IDuplicationCheckSession> CheckForDuplicate(string messageId, NServiceBus.Extensibility.ContextBag context);
     }
     public class InMemoryDeduplicationConfiguration : NServiceBus.Gateway.GatewayDeduplicationConfiguration
     {

--- a/src/NServiceBus.Gateway.Tests/ApprovalFiles/APIApprovals.Approve.netstandard.approved.txt
+++ b/src/NServiceBus.Gateway.Tests/ApprovalFiles/APIApprovals.Approve.netstandard.approved.txt
@@ -38,11 +38,15 @@ namespace NServiceBus.Gateway
     {
         System.Threading.Tasks.Task Send(string remoteAddress, System.Collections.Generic.IDictionary<string, string> headers, System.IO.Stream data);
     }
+    public interface IDuplicationCheckSession : System.IDisposable
+    {
+        bool IsDuplicate { get; }
+        System.Threading.Tasks.Task MarkAsDispatched();
+    }
     public interface IGatewayDeduplicationStorage
     {
         bool SupportsDistributedTransactions { get; }
-        System.Threading.Tasks.Task<bool> IsDuplicate(string messageId, NServiceBus.Extensibility.ContextBag context);
-        System.Threading.Tasks.Task MarkAsDispatched(string messageId, NServiceBus.Extensibility.ContextBag context);
+        System.Threading.Tasks.Task<NServiceBus.Gateway.IDuplicationCheckSession> CheckForDuplicate(string messageId, NServiceBus.Extensibility.ContextBag context);
     }
     public class InMemoryDeduplicationConfiguration : NServiceBus.Gateway.GatewayDeduplicationConfiguration
     {

--- a/src/NServiceBus.Gateway.Tests/ApprovalFiles/APIApprovals.Approve.netstandard.approved.txt
+++ b/src/NServiceBus.Gateway.Tests/ApprovalFiles/APIApprovals.Approve.netstandard.approved.txt
@@ -38,7 +38,7 @@ namespace NServiceBus.Gateway
     {
         System.Threading.Tasks.Task Send(string remoteAddress, System.Collections.Generic.IDictionary<string, string> headers, System.IO.Stream data);
     }
-    public interface IDuplicationCheckSession : System.IDisposable
+    public interface IDeduplicationSession : System.IDisposable
     {
         bool IsDuplicate { get; }
         System.Threading.Tasks.Task MarkAsDispatched();
@@ -46,7 +46,7 @@ namespace NServiceBus.Gateway
     public interface IGatewayDeduplicationStorage
     {
         bool SupportsDistributedTransactions { get; }
-        System.Threading.Tasks.Task<NServiceBus.Gateway.IDuplicationCheckSession> CheckForDuplicate(string messageId, NServiceBus.Extensibility.ContextBag context);
+        System.Threading.Tasks.Task<NServiceBus.Gateway.IDeduplicationSession> CheckForDuplicate(string messageId, NServiceBus.Extensibility.ContextBag context);
     }
     public class InMemoryDeduplicationConfiguration : NServiceBus.Gateway.GatewayDeduplicationConfiguration
     {

--- a/src/NServiceBus.Gateway.Tests/InMemoryStorage/InMemoryDeduplicationStorageTests.cs
+++ b/src/NServiceBus.Gateway.Tests/InMemoryStorage/InMemoryDeduplicationStorageTests.cs
@@ -12,16 +12,37 @@
         {
             var storage = new InMemoryDeduplicationStorage(2);
 
-            await storage.MarkAsDispatched("A", new ContextBag());
-            Assert.True(await storage.IsDuplicate("A", new ContextBag()));
+            using (var s1 = await storage.IsDuplicate("A", new ContextBag()))
+            {
+                await s1.MarkAsDispatched();
+            }
+            using (var s1 = await storage.IsDuplicate("A", new ContextBag()))
+            {
+                Assert.IsTrue(s1.IsDuplicate);
+            }
 
-            await storage.MarkAsDispatched("B", new ContextBag());
-            Assert.True(await storage.IsDuplicate("A", new ContextBag()));
+            using (var s1 = await storage.IsDuplicate("B", new ContextBag()))
+            {
+                await s1.MarkAsDispatched();
+            }
+            using (var s1 = await storage.IsDuplicate("B", new ContextBag()))
+            {
+                Assert.IsTrue(s1.IsDuplicate);
+            }
 
-            await storage.MarkAsDispatched("C", new ContextBag());
-            Assert.True(await storage.IsDuplicate("B", new ContextBag()));
-            Assert.True(await storage.IsDuplicate("C", new ContextBag()));
-            Assert.False(await storage.IsDuplicate("A", new ContextBag()));
+            using (var s1 = await storage.IsDuplicate("C", new ContextBag()))
+            {
+                await s1.MarkAsDispatched();
+            }
+            using (var s1 = await storage.IsDuplicate("C", new ContextBag()))
+            {
+                Assert.IsTrue(s1.IsDuplicate);
+            }
+
+            using (var s1 = await storage.IsDuplicate("A", new ContextBag()))
+            {
+                Assert.IsFalse(s1.IsDuplicate);
+            }
         }
     }
 }

--- a/src/NServiceBus.Gateway.Tests/InMemoryStorage/InMemoryDeduplicationStorageTests.cs
+++ b/src/NServiceBus.Gateway.Tests/InMemoryStorage/InMemoryDeduplicationStorageTests.cs
@@ -12,34 +12,34 @@
         {
             var storage = new InMemoryDeduplicationStorage(2);
 
-            using (var s1 = await storage.IsDuplicate("A", new ContextBag()))
+            using (var s1 = await storage.CheckForDuplicate("A", new ContextBag()))
             {
                 await s1.MarkAsDispatched();
             }
-            using (var s1 = await storage.IsDuplicate("A", new ContextBag()))
+            using (var s1 = await storage.CheckForDuplicate("A", new ContextBag()))
             {
                 Assert.IsTrue(s1.IsDuplicate);
             }
 
-            using (var s1 = await storage.IsDuplicate("B", new ContextBag()))
+            using (var s1 = await storage.CheckForDuplicate("B", new ContextBag()))
             {
                 await s1.MarkAsDispatched();
             }
-            using (var s1 = await storage.IsDuplicate("B", new ContextBag()))
+            using (var s1 = await storage.CheckForDuplicate("B", new ContextBag()))
             {
                 Assert.IsTrue(s1.IsDuplicate);
             }
 
-            using (var s1 = await storage.IsDuplicate("C", new ContextBag()))
+            using (var s1 = await storage.CheckForDuplicate("C", new ContextBag()))
             {
                 await s1.MarkAsDispatched();
             }
-            using (var s1 = await storage.IsDuplicate("C", new ContextBag()))
+            using (var s1 = await storage.CheckForDuplicate("C", new ContextBag()))
             {
                 Assert.IsTrue(s1.IsDuplicate);
             }
 
-            using (var s1 = await storage.IsDuplicate("A", new ContextBag()))
+            using (var s1 = await storage.CheckForDuplicate("A", new ContextBag()))
             {
                 Assert.IsFalse(s1.IsDuplicate);
             }

--- a/src/NServiceBus.Gateway/Deduplication/LegacyDeduplicationWrapper.cs
+++ b/src/NServiceBus.Gateway/Deduplication/LegacyDeduplicationWrapper.cs
@@ -18,14 +18,14 @@
         {
             var isNewMessage = await legacyPersister.DeduplicateMessage(messageId, DateTime.UtcNow, context)
                 .ConfigureAwait(false);
-            return new DummyLegacySession(!isNewMessage);
+            return new LegayDuplicationCheckSession(!isNewMessage);
         }
 
         IDeduplicateMessages legacyPersister;
 
-        class DummyLegacySession : IDuplicationCheckSession
+        class LegayDuplicationCheckSession : IDuplicationCheckSession
         {
-            public DummyLegacySession(bool isDuplicate)
+            public LegayDuplicationCheckSession(bool isDuplicate)
             {
                 IsDuplicate = isDuplicate;
             }

--- a/src/NServiceBus.Gateway/Deduplication/LegacyDeduplicationWrapper.cs
+++ b/src/NServiceBus.Gateway/Deduplication/LegacyDeduplicationWrapper.cs
@@ -14,7 +14,7 @@
 
         public bool SupportsDistributedTransactions { get; } = true;
 
-        public async Task<IDuplicationCheckSession> IsDuplicate(string messageId, ContextBag context)
+        public async Task<IDuplicationCheckSession> CheckForDuplicate(string messageId, ContextBag context)
         {
             var isNewMessage = await legacyPersister.DeduplicateMessage(messageId, DateTime.UtcNow, context)
                 .ConfigureAwait(false);

--- a/src/NServiceBus.Gateway/Deduplication/LegacyDeduplicationWrapper.cs
+++ b/src/NServiceBus.Gateway/Deduplication/LegacyDeduplicationWrapper.cs
@@ -14,18 +14,18 @@
 
         public bool SupportsDistributedTransactions { get; } = true;
 
-        public async Task<IDuplicationCheckSession> CheckForDuplicate(string messageId, ContextBag context)
+        public async Task<IDeduplicationSession> CheckForDuplicate(string messageId, ContextBag context)
         {
             var isNewMessage = await legacyPersister.DeduplicateMessage(messageId, DateTime.UtcNow, context)
                 .ConfigureAwait(false);
-            return new LegacyDuplicationCheckSession(!isNewMessage);
+            return new LegacyDeduplicationSession(!isNewMessage);
         }
 
         IDeduplicateMessages legacyPersister;
 
-        class LegacyDuplicationCheckSession : IDuplicationCheckSession
+        class LegacyDeduplicationSession : IDeduplicationSession
         {
-            public LegacyDuplicationCheckSession(bool isDuplicate)
+            public LegacyDeduplicationSession(bool isDuplicate)
             {
                 IsDuplicate = isDuplicate;
             }

--- a/src/NServiceBus.Gateway/Deduplication/LegacyDeduplicationWrapper.cs
+++ b/src/NServiceBus.Gateway/Deduplication/LegacyDeduplicationWrapper.cs
@@ -18,14 +18,14 @@
         {
             var isNewMessage = await legacyPersister.DeduplicateMessage(messageId, DateTime.UtcNow, context)
                 .ConfigureAwait(false);
-            return new LegayDuplicationCheckSession(!isNewMessage);
+            return new LegacyDuplicationCheckSession(!isNewMessage);
         }
 
         IDeduplicateMessages legacyPersister;
 
-        class LegayDuplicationCheckSession : IDuplicationCheckSession
+        class LegacyDuplicationCheckSession : IDuplicationCheckSession
         {
-            public LegayDuplicationCheckSession(bool isDuplicate)
+            public LegacyDuplicationCheckSession(bool isDuplicate)
             {
                 IsDuplicate = isDuplicate;
             }

--- a/src/NServiceBus.Gateway/IDeduplicationSession.cs
+++ b/src/NServiceBus.Gateway/IDeduplicationSession.cs
@@ -6,7 +6,7 @@
     /// <summary>
     /// Indicates whether a message is a duplicate or allows to mark it as dispatched.
     /// </summary>
-    public interface IDuplicationCheckSession : IDisposable
+    public interface IDeduplicationSession : IDisposable
     {
         /// <summary>
         /// Returns if the message is a duplicate.

--- a/src/NServiceBus.Gateway/IDuplicationCheckSession.cs
+++ b/src/NServiceBus.Gateway/IDuplicationCheckSession.cs
@@ -4,7 +4,7 @@
     using System.Threading.Tasks;
 
     /// <summary>
-    /// 
+    /// Indicates whether a message is a duplicate or allows to mark it as dispatched.
     /// </summary>
     public interface IDuplicationCheckSession : IDisposable
     {

--- a/src/NServiceBus.Gateway/IDuplicationCheckSession.cs
+++ b/src/NServiceBus.Gateway/IDuplicationCheckSession.cs
@@ -1,0 +1,21 @@
+﻿namespace NServiceBus.Gateway
+{
+    using System;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public interface IDuplicationCheckSession : IDisposable
+    {
+        /// <summary>
+        /// Returns if the message is a duplicate.
+        /// </summary>
+        bool IsDuplicate { get; }
+
+        /// <summary>
+        /// Marks the message as successfully dispatched. Marking a message as dispatched will consider it a duplicate when invoking <see cref="IGatewayDeduplicationStorage.CheckForDuplicate"/>.
+        /// </summary>
+        Task MarkAsDispatched();
+    }
+}

--- a/src/NServiceBus.Gateway/IGatewayDeduplicationStorage.cs
+++ b/src/NServiceBus.Gateway/IGatewayDeduplicationStorage.cs
@@ -15,10 +15,10 @@
         bool SupportsDistributedTransactions { get; }
 
         /// <summary>
-        /// Returns if the message is a duplicate.
+        /// Returns a session that provides duplicate detection for the given message id.
         /// </summary>
         /// <returns>
-        /// <code>true</code> if the message has been received successfully before and is considered a duplicate. <code>false</code> otherwise.
+        /// A <see cref="IDeduplicationSession"/>
         /// </returns>
         Task<IDeduplicationSession> CheckForDuplicate(string messageId, ContextBag context);
     }

--- a/src/NServiceBus.Gateway/IGatewayDeduplicationStorage.cs
+++ b/src/NServiceBus.Gateway/IGatewayDeduplicationStorage.cs
@@ -1,6 +1,5 @@
 ﻿namespace NServiceBus.Gateway
 {
-    using System;
     using System.Threading.Tasks;
     using System.Transactions;
     using Extensibility;
@@ -21,22 +20,6 @@
         /// <returns>
         /// <code>true</code> if the message has been received successfully before and is considered a duplicate. <code>false</code> otherwise.
         /// </returns>
-        Task<IDuplicationCheckSession> IsDuplicate(string messageId, ContextBag context);
-    }
-
-    /// <summary>
-    /// 
-    /// </summary>
-    public interface IDuplicationCheckSession : IDisposable
-    {
-        /// <summary>
-        /// Returns if the message is a duplicate.
-        /// </summary>
-        bool IsDuplicate { get; }
-
-        /// <summary>
-        /// Marks the message as successfully dispatched. Marking a message as dispatched will consider it a duplicate when invoking <see cref="IGatewayDeduplicationStorage.IsDuplicate"/>.
-        /// </summary>
-        Task MarkAsDispatched();
+        Task<IDuplicationCheckSession> CheckForDuplicate(string messageId, ContextBag context);
     }
 }

--- a/src/NServiceBus.Gateway/IGatewayDeduplicationStorage.cs
+++ b/src/NServiceBus.Gateway/IGatewayDeduplicationStorage.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Gateway
 {
+    using System;
     using System.Threading.Tasks;
     using System.Transactions;
     using Extensibility;
@@ -20,11 +21,22 @@
         /// <returns>
         /// <code>true</code> if the message has been received successfully before and is considered a duplicate. <code>false</code> otherwise.
         /// </returns>
-        Task<bool> IsDuplicate(string messageId, ContextBag context);
+        Task<IDuplicationCheckSession> IsDuplicate(string messageId, ContextBag context);
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public interface IDuplicationCheckSession : IDisposable
+    {
+        /// <summary>
+        /// Returns if the message is a duplicate.
+        /// </summary>
+        bool IsDuplicate { get; }
 
         /// <summary>
-        /// Marks the message as successfully dispatched. Marking a message as dispatched will consider it a duplicate when invoking <see cref="IsDuplicate"/>.
+        /// Marks the message as successfully dispatched. Marking a message as dispatched will consider it a duplicate when invoking <see cref="IGatewayDeduplicationStorage.IsDuplicate"/>.
         /// </summary>
-        Task MarkAsDispatched(string messageId, ContextBag context);
+        Task MarkAsDispatched();
     }
 }

--- a/src/NServiceBus.Gateway/IGatewayDeduplicationStorage.cs
+++ b/src/NServiceBus.Gateway/IGatewayDeduplicationStorage.cs
@@ -20,6 +20,6 @@
         /// <returns>
         /// <code>true</code> if the message has been received successfully before and is considered a duplicate. <code>false</code> otherwise.
         /// </returns>
-        Task<IDuplicationCheckSession> CheckForDuplicate(string messageId, ContextBag context);
+        Task<IDeduplicationSession> CheckForDuplicate(string messageId, ContextBag context);
     }
 }

--- a/src/NServiceBus.Gateway/InMemoryStorage/InMemoryDeduplicationSession.cs
+++ b/src/NServiceBus.Gateway/InMemoryStorage/InMemoryDeduplicationSession.cs
@@ -1,42 +1,51 @@
 ﻿namespace NServiceBus.Gateway
 {
-    using System;
     using System.Collections.Generic;
-    using System.Threading;
     using System.Threading.Tasks;
 
     class InMemoryDeduplicationSession : IDuplicationCheckSession
     {
-        public InMemoryDeduplicationSession(string messageId, Dictionary<string, LinkedListNode<string>> clientIdSet, LinkedList<string> clientIdList, object lockObj, int cacheSize)
+        public InMemoryDeduplicationSession(string messageId, Dictionary<string, LinkedListNode<string>> clientIdSet, LinkedList<string> clientIdList, int cacheSize)
         {
             this.messageId = messageId;
             this.clientIdSet = clientIdSet;
             this.clientIdList = clientIdList;
-            this.lockObj = lockObj;
             this.cacheSize = cacheSize;
         }
 
-        public bool IsDuplicate => clientIdSet.ContainsKey(messageId);
+        public bool IsDuplicate
+        {
+            get
+            {
+                lock (lockObj)
+                {
+                    return clientIdSet.ContainsKey(messageId);
+                }
+            }
+        }
 
         public Task MarkAsDispatched()
         {
-            if (clientIdSet.TryGetValue(messageId, out var existingNode)) // O(1)
+            lock (lockObj)
             {
-                // "refresh" lifetime by moving id to the back of the linked list
-                clientIdList.Remove(existingNode); // O(1) operation, because we got the node reference
-                clientIdList.AddLast(existingNode); // O(1) operation
-            }
-            else
-            {
-                if (clientIdSet.Count == cacheSize)
+                if (clientIdSet.TryGetValue(messageId, out var existingNode)) // O(1)
                 {
-                    var id = clientIdList.First.Value;
-                    clientIdSet.Remove(id); // O(1)
-                    clientIdList.RemoveFirst(); // O(1)
+                    // "refresh" lifetime by moving id to the back of the linked list
+                    clientIdList.Remove(existingNode); // O(1) operation, because we got the node reference
+                    clientIdList.AddLast(existingNode); // O(1) operation
                 }
+                else
+                {
+                    if (clientIdSet.Count == cacheSize)
+                    {
+                        var id = clientIdList.First.Value;
+                        clientIdSet.Remove(id); // O(1)
+                        clientIdList.RemoveFirst(); // O(1)
+                    }
 
-                var node = clientIdList.AddLast(messageId); // O(1)
-                clientIdSet.Add(messageId, node); // O(1)
+                    var node = clientIdList.AddLast(messageId); // O(1)
+                    clientIdSet.Add(messageId, node); // O(1)
+                }
             }
 
             return Task.FromResult(0);
@@ -44,14 +53,13 @@
 
         public void Dispose()
         {
-            Monitor.Exit(lockObj);
-            GC.SuppressFinalize(this);
         }
 
         readonly string messageId;
         readonly Dictionary<string, LinkedListNode<string>> clientIdSet;
         readonly LinkedList<string> clientIdList;
-        readonly object lockObj;
         readonly int cacheSize;
+
+        static readonly object lockObj = new object();
     }
 }

--- a/src/NServiceBus.Gateway/InMemoryStorage/InMemoryDeduplicationSession.cs
+++ b/src/NServiceBus.Gateway/InMemoryStorage/InMemoryDeduplicationSession.cs
@@ -1,0 +1,57 @@
+﻿namespace NServiceBus.Gateway
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    class InMemoryDeduplicationSession : IDuplicationCheckSession
+    {
+        public InMemoryDeduplicationSession(string messageId, Dictionary<string, LinkedListNode<string>> clientIdSet, LinkedList<string> clientIdList, object lockObj, int cacheSize)
+        {
+            this.messageId = messageId;
+            this.clientIdSet = clientIdSet;
+            this.clientIdList = clientIdList;
+            this.lockObj = lockObj;
+            this.cacheSize = cacheSize;
+        }
+
+        public bool IsDuplicate => clientIdSet.ContainsKey(messageId);
+
+        public Task MarkAsDispatched()
+        {
+            if (clientIdSet.TryGetValue(messageId, out var existingNode)) // O(1)
+            {
+                // "refresh" lifetime by moving id to the back of the linked list
+                clientIdList.Remove(existingNode); // O(1) operation, because we got the node reference
+                clientIdList.AddLast(existingNode); // O(1) operation
+            }
+            else
+            {
+                if (clientIdSet.Count == cacheSize)
+                {
+                    var id = clientIdList.First.Value;
+                    clientIdSet.Remove(id); // O(1)
+                    clientIdList.RemoveFirst(); // O(1)
+                }
+
+                var node = clientIdList.AddLast(messageId); // O(1)
+                clientIdSet.Add(messageId, node); // O(1)
+            }
+
+            return Task.FromResult(0);
+        }
+
+        public void Dispose()
+        {
+            Monitor.Exit(lockObj);
+            GC.SuppressFinalize(this);
+        }
+
+        readonly string messageId;
+        readonly Dictionary<string, LinkedListNode<string>> clientIdSet;
+        readonly LinkedList<string> clientIdList;
+        readonly object lockObj;
+        readonly int cacheSize;
+    }
+}

--- a/src/NServiceBus.Gateway/InMemoryStorage/InMemoryDeduplicationSession.cs
+++ b/src/NServiceBus.Gateway/InMemoryStorage/InMemoryDeduplicationSession.cs
@@ -17,7 +17,7 @@
         {
             get
             {
-                lock (lockObj)
+                lock (clientIdSet)
                 {
                     return clientIdSet.ContainsKey(messageId);
                 }
@@ -26,7 +26,7 @@
 
         public Task MarkAsDispatched()
         {
-            lock (lockObj)
+            lock (clientIdSet)
             {
                 if (clientIdSet.TryGetValue(messageId, out var existingNode)) // O(1)
                 {
@@ -59,7 +59,5 @@
         readonly Dictionary<string, LinkedListNode<string>> clientIdSet;
         readonly LinkedList<string> clientIdList;
         readonly int cacheSize;
-
-        static readonly object lockObj = new object();
     }
 }

--- a/src/NServiceBus.Gateway/InMemoryStorage/InMemoryDeduplicationSession.cs
+++ b/src/NServiceBus.Gateway/InMemoryStorage/InMemoryDeduplicationSession.cs
@@ -3,7 +3,7 @@
     using System.Collections.Generic;
     using System.Threading.Tasks;
 
-    class InMemoryDeduplicationSession : IDuplicationCheckSession
+    class InMemoryDeduplicationSession : IDeduplicationSession
     {
         public InMemoryDeduplicationSession(string messageId, Dictionary<string, LinkedListNode<string>> clientIdSet, LinkedList<string> clientIdList, int cacheSize)
         {

--- a/src/NServiceBus.Gateway/InMemoryStorage/InMemoryDeduplicationStorage.cs
+++ b/src/NServiceBus.Gateway/InMemoryStorage/InMemoryDeduplicationStorage.cs
@@ -54,6 +54,7 @@
             public void Dispose()
             {
                 Monitor.Exit(lockObj);
+                GC.SuppressFinalize(this);                
             }
         }
 

--- a/src/NServiceBus.Gateway/InMemoryStorage/InMemoryDeduplicationStorage.cs
+++ b/src/NServiceBus.Gateway/InMemoryStorage/InMemoryDeduplicationStorage.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.Gateway
 {
     using System.Collections.Generic;
-    using System.Threading;
     using System.Threading.Tasks;
     using Extensibility;
 
@@ -16,13 +15,12 @@
 
         public Task<IDuplicationCheckSession> CheckForDuplicate(string messageId, ContextBag context)
         {
-            Monitor.Enter(lockObj);
-            return Task.FromResult<IDuplicationCheckSession>(new InMemoryDeduplicationSession(messageId, clientIdSet, clientIdList, lockObj, cacheSize));
+            return Task.FromResult<IDuplicationCheckSession>(
+                new InMemoryDeduplicationSession(messageId, clientIdSet, clientIdList, cacheSize));
         }
 
         readonly int cacheSize;
         readonly LinkedList<string> clientIdList = new LinkedList<string>();
         readonly Dictionary<string, LinkedListNode<string>> clientIdSet = new Dictionary<string, LinkedListNode<string>>();
-        readonly object lockObj = new object();
     }
 }

--- a/src/NServiceBus.Gateway/InMemoryStorage/InMemoryDeduplicationStorage.cs
+++ b/src/NServiceBus.Gateway/InMemoryStorage/InMemoryDeduplicationStorage.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Gateway
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
@@ -70,7 +71,7 @@
 
         public bool SupportsDistributedTransactions { get; } = false;
 
-        public Task<IDuplicationCheckSession> IsDuplicate(string messageId, ContextBag context)
+        public Task<IDuplicationCheckSession> CheckForDuplicate(string messageId, ContextBag context)
         {
             Monitor.Enter(clientIdSet);
             return Task.FromResult<IDuplicationCheckSession>(new InMemoryDeduplicationSession(messageId, clientIdSet, clientIdList, lockObj, cacheSize));

--- a/src/NServiceBus.Gateway/InMemoryStorage/InMemoryDeduplicationStorage.cs
+++ b/src/NServiceBus.Gateway/InMemoryStorage/InMemoryDeduplicationStorage.cs
@@ -1,6 +1,5 @@
 ﻿namespace NServiceBus.Gateway
 {
-    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
@@ -8,62 +7,6 @@
 
     class InMemoryDeduplicationStorage : IGatewayDeduplicationStorage
     {
-        class InMemoryDeduplicationSession : IDuplicationCheckSession
-        {
-            readonly string messageId;
-            readonly Dictionary<string, LinkedListNode<string>> clientIdSet;
-            readonly LinkedList<string> clientIdList;
-            readonly object lockObj;
-            readonly int cacheSize;
-
-
-            public InMemoryDeduplicationSession(string messageId, Dictionary<string, LinkedListNode<string>> clientIdSet, LinkedList<string> clientIdList, object lockObj, int cacheSize)
-            {
-                this.messageId = messageId;
-                this.clientIdSet = clientIdSet;
-                this.clientIdList = clientIdList;
-                this.lockObj = lockObj;
-                this.cacheSize = cacheSize;
-            }
-
-            public bool IsDuplicate => clientIdSet.ContainsKey(messageId);
-
-            public Task MarkAsDispatched()
-            {
-                if (clientIdSet.TryGetValue(messageId, out var existingNode)) // O(1)
-                {
-                    // "refresh" lifetime by moving id to the back of the linked list
-                    clientIdList.Remove(existingNode); // O(1) operation, because we got the node reference
-                    clientIdList.AddLast(existingNode); // O(1) operation
-                }
-                else
-                {
-                    if (clientIdSet.Count == cacheSize)
-                    {
-                        var id = clientIdList.First.Value;
-                        clientIdSet.Remove(id); // O(1)
-                        clientIdList.RemoveFirst(); // O(1)
-                    }
-
-                    var node = clientIdList.AddLast(messageId); // O(1)
-                    clientIdSet.Add(messageId, node); // O(1)
-                }
-
-                return Task.FromResult(0);
-            }
-
-            public void Dispose()
-            {
-                Monitor.Exit(lockObj);
-                GC.SuppressFinalize(this);                
-            }
-        }
-
-        readonly int cacheSize;
-        readonly LinkedList<string> clientIdList = new LinkedList<string>();
-        readonly Dictionary<string, LinkedListNode<string>> clientIdSet = new Dictionary<string, LinkedListNode<string>>();
-        readonly object lockObj = new object();
-
         public InMemoryDeduplicationStorage(int cacheSize)
         {
             this.cacheSize = cacheSize;
@@ -76,5 +19,10 @@
             Monitor.Enter(clientIdSet);
             return Task.FromResult<IDuplicationCheckSession>(new InMemoryDeduplicationSession(messageId, clientIdSet, clientIdList, lockObj, cacheSize));
         }
-    }   
+
+        readonly int cacheSize;
+        readonly LinkedList<string> clientIdList = new LinkedList<string>();
+        readonly Dictionary<string, LinkedListNode<string>> clientIdSet = new Dictionary<string, LinkedListNode<string>>();
+        readonly object lockObj = new object();
+    }
 }

--- a/src/NServiceBus.Gateway/InMemoryStorage/InMemoryDeduplicationStorage.cs
+++ b/src/NServiceBus.Gateway/InMemoryStorage/InMemoryDeduplicationStorage.cs
@@ -13,9 +13,9 @@
 
         public bool SupportsDistributedTransactions { get; } = false;
 
-        public Task<IDuplicationCheckSession> CheckForDuplicate(string messageId, ContextBag context)
+        public Task<IDeduplicationSession> CheckForDuplicate(string messageId, ContextBag context)
         {
-            return Task.FromResult<IDuplicationCheckSession>(
+            return Task.FromResult<IDeduplicationSession>(
                 new InMemoryDeduplicationSession(messageId, clientIdSet, clientIdList, cacheSize));
         }
 

--- a/src/NServiceBus.Gateway/InMemoryStorage/InMemoryDeduplicationStorage.cs
+++ b/src/NServiceBus.Gateway/InMemoryStorage/InMemoryDeduplicationStorage.cs
@@ -16,7 +16,7 @@
 
         public Task<IDuplicationCheckSession> CheckForDuplicate(string messageId, ContextBag context)
         {
-            Monitor.Enter(clientIdSet);
+            Monitor.Enter(lockObj);
             return Task.FromResult<IDuplicationCheckSession>(new InMemoryDeduplicationSession(messageId, clientIdSet, clientIdList, lockObj, cacheSize));
         }
 

--- a/src/NServiceBus.Gateway/Receiving/SingleCallChannelReceiver.cs
+++ b/src/NServiceBus.Gateway/Receiving/SingleCallChannelReceiver.cs
@@ -114,7 +114,7 @@
                 {
                     if (duplicationCheck.IsDuplicate)
                     {
-                        Logger.InfoFormat("Message with id: {0} is already on the bus, dropping the request", callInfo.ClientId);
+                        Logger.InfoFormat("Message with id: {0} has already been dispatched, ignoring incoming gateway message.", callInfo.ClientId);
                     }
                     else
                     {
@@ -128,7 +128,7 @@
                             // swallow exception in non-dtc modes.
                             // When using no transactions, the message has been sent to the transport already. Throwing would cause the operation to be retried and a guaranteed duplicate to be created. By swallowing the exception, the duplicate is only created if the same message is sent to the gateway for another reason.
                             // When using distributed transactions, throw so that both persistence and transport can rollback atomically.
-                            Logger.Warn($"Failed to mark message with id '{callInfo.ClientId}' as dispatched. This message won't be deduplicated.'", e);
+                            Logger.Warn($"Failed to mark message with id '{callInfo.ClientId}' as dispatched. This message might not be deduplicated.'", e);
                         }
                     }
                 }

--- a/src/NServiceBus.Gateway/Receiving/SingleCallChannelReceiver.cs
+++ b/src/NServiceBus.Gateway/Receiving/SingleCallChannelReceiver.cs
@@ -32,7 +32,7 @@
         }
 
         public Task Stop()
-        { 
+        {
             return channelReceiver?.Stop();
         }
 
@@ -46,7 +46,6 @@
 
                 if (useTransactionScope)
                 {
-                    
                     using (var scope = GatewayTransaction.Scope())
                     {
                         await Receive(callInfo).ConfigureAwait(false);
@@ -88,10 +87,10 @@
                 {
                     await Hasher.Verify(stream, callInfo.Md5).ConfigureAwait(false);
                 }
-                
+
                 var headers = headerManager.ReassembleDataBusProperties(callInfo.ClientId, callInfo.Headers);
                 var args = CreateMessageReceivedArgsWithDefaultValues(callInfo.TimeToBeReceived, headers[NServiceBus + Id]);
-                
+
                 var isGatewayMessage = IsGatewayMessage(headers);
                 if (isGatewayMessage)
                 {
@@ -103,7 +102,7 @@
                 {
                     args.Headers = MapCustomMessageHeaders(headers);
                 }
-          
+
                 var body = new byte[stream.Length];
                 await stream.ReadAsync(body, 0, body.Length).ConfigureAwait(false);
                 args.Body = body;
@@ -175,7 +174,7 @@
         static Dictionary<string, string> MapCustomMessageHeaders(IDictionary<string, string> receivedHeaders)
         {
             var headers = new Dictionary<string, string>();
-            
+
             foreach (var header in receivedHeaders)
             {
                 headers[header.Key] = header.Value;
@@ -226,7 +225,7 @@
             var specificDataBusHeaderToUpdate = callInfo.ReadDataBus();
             headerManager.InsertHeader(callInfo.ClientId, specificDataBusHeaderToUpdate, newDatabusKey);
         }
-        
+
         static ILog Logger = LogManager.GetLogger("NServiceBus.Gateway");
 
         Func<string, IChannelReceiver> channelFactory;

--- a/src/NServiceBus.Gateway/Receiving/SingleCallChannelReceiver.cs
+++ b/src/NServiceBus.Gateway/Receiving/SingleCallChannelReceiver.cs
@@ -110,7 +110,7 @@
 
                 var context = new ContextBag();
 
-                using (var duplicationCheck = await deduplicationStorage.IsDuplicate(callInfo.ClientId, context).ConfigureAwait(false))
+                using (var duplicationCheck = await deduplicationStorage.CheckForDuplicate(callInfo.ClientId, context).ConfigureAwait(false))
                 {
                     if (duplicationCheck.IsDuplicate)
                     {


### PR DESCRIPTION
an attempt to design a different gateway API to allow persisters to make use of transactions by introducing a session that links the `IsDuplicate` check with the `MarkAsDispatched` operation.

the current API approach looks roughly like this:
```c#
if(!storage.IsDuplicate(messageId))
{
    transport.Dispatch(message);
    storage.MarkAsDispatched(messageID);
}
```
this makes it difficult for persistence to make use of session/transaction based functionalities like "select for update" as it's not really possible to open and share a transaction between these storage operations.

This approach might solve this problem:

```c#
using(var session = storage.IsDuplicate(message))
{
   if(!session.IsDuplicate)
   {
        transport.Dispatch(message);
        session.MarkAsDispatched();
   }
}
```

the session can encapsulate a transaction and share it easily with the `MarkAsDispatched` operation while having a clear lifetime due to the usage of `IDisposable`