### PR TITLE
Skip installer when not running on Windows

### DIFF
--- a/src/NServiceBus.Gateway/Installer/GatewayHttpListenerInstaller.cs
+++ b/src/NServiceBus.Gateway/Installer/GatewayHttpListenerInstaller.cs
@@ -34,6 +34,12 @@ namespace NServiceBus.Installation
                 return Task.FromResult(0);
             }
 
+            if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+            {
+                logger.InfoFormat("Installer does not support platform {0}. Ensure that the process has required permissions to use listen to configured urls.", Environment.OSVersion.Platform.ToString("G"));
+                return Task.FromResult(0);
+            }
+
             if (Environment.OSVersion.Version.Major <= 5)
             {
                 logger.InfoFormat(

--- a/src/NServiceBus.Gateway/Installer/GatewayHttpListenerInstaller.cs
+++ b/src/NServiceBus.Gateway/Installer/GatewayHttpListenerInstaller.cs
@@ -2,6 +2,9 @@ namespace NServiceBus.Installation
 {
     using System;
     using System.Diagnostics;
+#if NETSTANDARD
+    using System.Runtime.InteropServices;
+#endif    
     using System.IO;
     using System.Threading.Tasks;
     using Gateway.Installer;
@@ -34,9 +37,16 @@ namespace NServiceBus.Installation
                 return Task.FromResult(0);
             }
 
+            #if NETSTANDARD
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                logger.InfoFormat("Installer does not support platform {0}. Ensure that the process has required permissions to listen to configured urls.", RuntimeInformation.OSDescription);
+                var platform = RuntimeInformation.OSDescription;
+            #else
+            if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+            {
+                var platform = Environment.OSVersion.Platform.ToString("G");
+            #endif
+                logger.InfoFormat("Installer does not support platform {0}. Ensure that the process has required permissions to listen to configured urls.", platform);
                 return Task.FromResult(0);
             }
 

--- a/src/NServiceBus.Gateway/Installer/GatewayHttpListenerInstaller.cs
+++ b/src/NServiceBus.Gateway/Installer/GatewayHttpListenerInstaller.cs
@@ -34,9 +34,9 @@ namespace NServiceBus.Installation
                 return Task.FromResult(0);
             }
 
-            if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                logger.InfoFormat("Installer does not support platform {0}. Ensure that the process has required permissions to use listen to configured urls.", Environment.OSVersion.Platform.ToString("G"));
+                logger.InfoFormat("Installer does not support platform {0}. Ensure that the process has required permissions to listen to configured urls.", RuntimeInformation.OSDescription);
                 return Task.FromResult(0);
             }
 


### PR DESCRIPTION
When running on linux, the installer seems to usually trip over `Environment.OSVersion.Version.Major <= 5` and not run the installer (which is correct). The behavior does seem to be "lucky coincidence"  and instead we should avoid running the installer logic when not running on Windows.