### PR TITLE
Legacy storage detection

### DIFF
--- a/src/NServiceBus.Gateway.AcceptanceTests/When_using_legacy_inmemory_persistence.cs
+++ b/src/NServiceBus.Gateway.AcceptanceTests/When_using_legacy_inmemory_persistence.cs
@@ -1,0 +1,39 @@
+﻿namespace NServiceBus.Gateway.AcceptanceTests
+{
+    using System.Linq;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using Logging;
+    using NUnit.Framework;
+
+    public class When_using_legacy_inmemory_persistence : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_log_warning()
+        {
+            var context = await Scenario.Define<ScenarioContext>()
+                .WithEndpoint<EndpointWithLegacyConfiguration>()
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            var warnings = context.Logs
+                .Where(l => l.Level == LogLevel.Warn)
+                .Select(l => l.Message);
+            Assert.That(warnings.Any(l => l.Contains("Endpoint is configured to use the legacy in-memory gateway deduplication storage")));
+        }
+
+        class EndpointWithLegacyConfiguration : EndpointConfigurationBuilder
+        {
+            public EndpointWithLegacyConfiguration()
+            {
+                EndpointSetup<GatewayEndpointWithNoStorage>(c =>
+                {
+                    c.UsePersistence<InMemoryPersistence, StorageType.GatewayDeduplication>();
+                    
+                    // legacy configuration API (not passing a storage as parameter):
+                    c.Gateway();
+                });
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Gateway.AcceptanceTests/When_using_legacy_inmemory_persistence.cs
+++ b/src/NServiceBus.Gateway.AcceptanceTests/When_using_legacy_inmemory_persistence.cs
@@ -31,7 +31,8 @@
                     c.UsePersistence<InMemoryPersistence, StorageType.GatewayDeduplication>();
                     
                     // legacy configuration API (not passing a storage as parameter):
-                    c.Gateway();
+                    var gatewayConfiguration = c.Gateway();
+                    gatewayConfiguration.AddReceiveChannel("http://localhost:25999/SiteA/");
                 });
             }
         }

--- a/src/NServiceBus.Gateway/Deduplication/LegacyDeduplicationStorageConfiguration.cs
+++ b/src/NServiceBus.Gateway/Deduplication/LegacyDeduplicationStorageConfiguration.cs
@@ -3,6 +3,8 @@
     using System;
     using System.Collections.Generic;
     using Deduplication;
+    using Features;
+    using Logging;
     using ObjectBuilder;
     using Settings;
 
@@ -22,6 +24,11 @@
                 throw new Exception("No persistence configured, please configure one that supports gateway deduplication storage or provide a deduplication storage via the 'endpointConfiguration.Gateway' API.");
             }
 
+            if (settings.IsFeatureEnabled(typeof(InMemoryGatewayPersistence)))
+            {
+                log.WarnFormat("Endpoint is configured to use the legacy in-memory gateway deduplication storage. This storage is going to be obsoleted in future versions of NServiceBus. Use the gateway's built-in in-memory storage instead: endpointConfiguration.UseGateway(new {0}());'", nameof(InMemoryDeduplicationConfiguration));
+            }
+
             base.Setup(settings);
         }
 
@@ -29,5 +36,7 @@
         {
             return new LegacyDeduplicationWrapper(builder.Build<IDeduplicateMessages>());
         }
+
+        static ILog log = LogManager.GetLogger<LegacyDeduplicationStorageConfiguration>();
     }
 }

--- a/src/NServiceBus.Gateway/Deduplication/LegacyDeduplicationStorageConfiguration.cs
+++ b/src/NServiceBus.Gateway/Deduplication/LegacyDeduplicationStorageConfiguration.cs
@@ -26,7 +26,7 @@
 
             if (settings.IsFeatureEnabled(typeof(InMemoryGatewayPersistence)))
             {
-                log.WarnFormat("Endpoint is configured to use the legacy in-memory gateway deduplication storage. This storage is going to be obsoleted in future versions of NServiceBus. Use the gateway's built-in in-memory storage instead: endpointConfiguration.UseGateway(new {0}());'", nameof(InMemoryDeduplicationConfiguration));
+                log.Warn($"Endpoint is configured to use the legacy in-memory gateway deduplication storage. This storage is going to be obsoleted in future versions of NServiceBus. Use the gateway's built-in in-memory storage instead: endpointConfiguration.UseGateway(new {nameof(InMemoryDeduplicationConfiguration)}());'");
             }
 
             base.Setup(settings);


### PR DESCRIPTION
Adds a check to detect if core's in-memory implementation for the gateway storage is being used and logs a warning to use the built-in version of the gateway instead.