### PR TITLE
Always create TransactionScope when using legacy storages

### DIFF
--- a/src/NServiceBus.Gateway.AcceptanceTests/When_using_legacy_persistence.cs
+++ b/src/NServiceBus.Gateway.AcceptanceTests/When_using_legacy_persistence.cs
@@ -1,0 +1,106 @@
+﻿namespace NServiceBus.Gateway.AcceptanceTests
+{
+    using System;
+    using System.Threading.Tasks;
+    using System.Transactions;
+    using AcceptanceTesting;
+    using Configuration.AdvancedExtensibility;
+    using Deduplication;
+    using Extensibility;
+    using NUnit.Framework;
+    using Persistence;
+
+    public class When_using_legacy_storage
+    {
+        [Test]
+        public async Task Should_always_create_transaction_scope()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Sender>(e => e
+                    .When(s => s.SendToSites(new []{ "SiteA" }, new SomeMessage())))
+                .WithEndpoint<EndpointWithLegacyStorage>()
+                .Done(c => c.MessageReceived)
+                .Run();
+
+            Assert.IsTrue(context.HasAmbientTransaction);
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool HasAmbientTransaction { get; set; }
+            public bool MessageReceived { get; set; }
+        }
+
+        class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<GatewayEndpoint>(c =>
+                {
+                    var gatewaySettings = c.GetSettings().Get<GatewaySettings>();
+                    gatewaySettings.AddSite("SiteA", "http://localhost:25999/SiteA/");
+                    gatewaySettings.AddReceiveChannel("http://localhost:25999/SiteB/");
+                });
+            }
+        }
+
+        class EndpointWithLegacyStorage : EndpointConfigurationBuilder
+        {
+            public EndpointWithLegacyStorage()
+            {
+                EndpointSetup<GatewayEndpointWithNoStorage>((configuration, runDescriptor) =>
+                {
+                    var testContext = runDescriptor.ScenarioContext as Context;
+                    configuration.RegisterComponents(r => r.RegisterSingleton(typeof(IDeduplicateMessages), new FakeDeduplicationStorage(testContext)));
+                    configuration.UsePersistence<FakeDeduplicationPersistence, StorageType.GatewayDeduplication>();
+                    var gatewaySettings = configuration.Gateway();
+                    gatewaySettings.AddReceiveChannel("http://localhost:25999/SiteA/");
+                });
+            }
+
+            class SomeMessageHandler : IHandleMessages<SomeMessage>
+            {
+                Context testContext;
+
+                public SomeMessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(SomeMessage message, IMessageHandlerContext context)
+                {
+                    testContext.MessageReceived = true;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        class SomeMessage : IMessage
+        {
+        }
+
+        class FakeDeduplicationPersistence : PersistenceDefinition
+        {
+            public FakeDeduplicationPersistence()
+            {
+                Supports<StorageType.GatewayDeduplication>(_ => {});
+            }
+        }
+
+        class FakeDeduplicationStorage : IDeduplicateMessages
+        {
+            Context testContext;
+
+            public FakeDeduplicationStorage(Context testContext)
+            {
+                this.testContext = testContext;
+            }
+
+            public Task<bool> DeduplicateMessage(string clientId, DateTime timeReceived, ContextBag context)
+            {
+                testContext.HasAmbientTransaction = Transaction.Current != null;
+                return Task.FromResult(true);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Gateway/Gateway.cs
+++ b/src/NServiceBus.Gateway/Gateway.cs
@@ -189,6 +189,14 @@
                 // only use transaction scope if both transport and persistence are able to enlist with the transaction scope.
                 // If one of them cannot enlist, use no transaction scope as partial rollbacks of the deduplication process can cause incorrect side effects.
                 var useTransactionScope = deduplicationStorage.SupportsDistributedTransactions && transportTransactionMode == TransportTransactionMode.TransactionScope;
+
+                if (deduplicationStorage is LegacyDeduplicationWrapper)
+                {
+                    // the legacy deduplication storage requires the storage to support TransactionScope.
+                    // This is critical when using the gateway with a non-transactional transport as a dispatch failure must undo any potential persistence changes.
+                    useTransactionScope = true;
+                }
+
                 foreach (var receiveChannel in manageReceiveChannels.GetReceiveChannels())
                 {
                     var receiver = new SingleCallChannelReceiver(channelReceiverFactory, deduplicationStorage, databus, useTransactionScope);


### PR DESCRIPTION
The gateway only uses a transaction scope when both storage and transport support it (and the transport isn't configured to run on a lower transaction level). However, with the legacy implementation this can cause problems when running with transports which don't support transactions. Due to the way legacy persisters work, they require a transaction scope to rollback changes in case of a transport failure, so there always needs to be a transaction scope.