### PR TITLE
TreatAsErrorFromVersion must not be 3.0 as that prevent recompile

### DIFF
--- a/src/NServiceBus.Gateway/Gateway.cs
+++ b/src/NServiceBus.Gateway/Gateway.cs
@@ -28,8 +28,8 @@
     /// Used to configure the gateway.
     /// </summary>
     [ObsoleteEx(
-        RemoveInVersion = "4.0",
-        TreatAsErrorFromVersion = "4.0",
+        TreatAsErrorFromVersion = "4",
+        RemoveInVersion = "5",
         Message = "Use `EndpointConfiguration.Gateway() to enable the gateway.")]
     public class Gateway : Feature
     {

--- a/src/NServiceBus.Gateway/Gateway.cs
+++ b/src/NServiceBus.Gateway/Gateway.cs
@@ -29,7 +29,7 @@
     /// </summary>
     [ObsoleteEx(
         RemoveInVersion = "4.0",
-        TreatAsErrorFromVersion = "3.0",
+        TreatAsErrorFromVersion = "4.0",
         Message = "Use `EndpointConfiguration.Gateway() to enable the gateway.")]
     public class Gateway : Feature
     {


### PR DESCRIPTION
The gateway type must still be usable, but users should be getting a hint that they should migrate to the other gateway API.

Meaning in v3 a warning, in v4 an error with NotImplementedException and in v5 removed.