### PR TITLE
Provide endpoint name to tests

### DIFF
--- a/src/NServiceBus.Gateway.AcceptanceTests/GatewayEndpoint.cs
+++ b/src/NServiceBus.Gateway.AcceptanceTests/GatewayEndpoint.cs
@@ -11,8 +11,10 @@
         {
             return base.GetConfiguration(runDescriptor, endpointCustomizationConfiguration, configuration =>
             {
+                var endpointName = endpointCustomizationConfiguration.CustomEndpointName ?? configuration.GetSettings().EndpointName();
+
                 var deduplicationConfiguration = GatewayTestSuiteConstraints.Current.ConfigureDeduplicationStorage(
-                    endpointCustomizationConfiguration.CustomEndpointName,
+                    endpointName,
                     configuration,
                     runDescriptor.Settings)
                     .GetAwaiter().GetResult();


### PR DESCRIPTION
The endpoint name provided to `GatewayTestConstraints.ConfigureDeduplicationStorage(…)` was always null because it was only providing the "custom" endpoint name, which none of the tests ever provided. This will ensure that each test receives an endpoint name in either case.