### PR TITLE
Renamed InMemory to NonDurable

### DIFF
--- a/src/NServiceBus.Gateway.AcceptanceTests/InMemoryTestSuiteConstaints.cs
+++ b/src/NServiceBus.Gateway.AcceptanceTests/InMemoryTestSuiteConstaints.cs
@@ -8,7 +8,7 @@
     {
         public Task<GatewayDeduplicationConfiguration> ConfigureDeduplicationStorage(string endpointName, EndpointConfiguration configuration, RunSettings settings)
         {
-            return Task.FromResult<GatewayDeduplicationConfiguration>(new InMemoryDeduplicationConfiguration());
+            return Task.FromResult<GatewayDeduplicationConfiguration>(new NonDurableDeduplicationConfiguration());
         }
 
         public Task Cleanup()

--- a/src/NServiceBus.Gateway.AcceptanceTests/NServiceBus.Gateway.AcceptanceTests.csproj
+++ b/src/NServiceBus.Gateway.AcceptanceTests/NServiceBus.Gateway.AcceptanceTests.csproj
@@ -37,8 +37,8 @@
       <PackagePath>content\App_Packages\NSB.Gateway.AcceptanceTests\;contentFiles\cs\any\NSB.Gateway.AcceptanceTests\</PackagePath>
     </_PackageFiles>
     <_PackageFiles Remove="**\obj\**\*.cs" />
-    <_PackageFiles Remove="**\InMemoryPersistenceConfiguration.cs" />
-    <_PackageFiles Remove="**\InMemoryTestSuiteConstaints.cs" />
+    <_PackageFiles Remove="**\NonDurablePersistenceConfiguration.cs" />
+    <_PackageFiles Remove="**\NonDurableTestSuiteConstaints.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Gateway.PersistenceTests/InMemoryDeduplicationStorageConfiguration.cs
+++ b/src/NServiceBus.Gateway.PersistenceTests/InMemoryDeduplicationStorageConfiguration.cs
@@ -4,6 +4,6 @@ partial class GatewayPersistenceTestsConfiguration
 {
     public IGatewayDeduplicationStorage CreateStorage()
     {
-        return new InMemoryDeduplicationStorage(100);
+        return new NonDurableDeduplicationStorage(100);
     }
 }

--- a/src/NServiceBus.Gateway.PersistenceTests/NServiceBus.Gateway.PersistenceTests.csproj
+++ b/src/NServiceBus.Gateway.PersistenceTests/NServiceBus.Gateway.PersistenceTests.csproj
@@ -33,7 +33,7 @@
       <PackagePath>content\App_Packages\NSB.TransportTests\;contentFiles\cs\any\NSB.TransportTests\</PackagePath>
     </_PackageFiles>
     <_PackageFiles Remove="**\obj\**\*.cs" />
-    <_PackageFiles Remove="InMemoryDeduplicationStorageConfiguration.cs" />
+    <_PackageFiles Remove="NonDurableDeduplicationStorageConfiguration.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\TestSuppressions.cs" Link="TestSuppressions.cs" />

--- a/src/NServiceBus.Gateway.Tests/ApprovalFiles/APIApprovals.Approve.netframework.approved.txt
+++ b/src/NServiceBus.Gateway.Tests/ApprovalFiles/APIApprovals.Approve.netframework.approved.txt
@@ -41,9 +41,9 @@ namespace NServiceBus.Gateway
         bool SupportsDistributedTransactions { get; }
         System.Threading.Tasks.Task<NServiceBus.Gateway.IDeduplicationSession> CheckForDuplicate(string messageId, NServiceBus.Extensibility.ContextBag context);
     }
-    public class InMemoryDeduplicationConfiguration : NServiceBus.Gateway.GatewayDeduplicationConfiguration
+    public class NonDurableDeduplicationConfiguration : NServiceBus.Gateway.GatewayDeduplicationConfiguration
     {
-        public InMemoryDeduplicationConfiguration() { }
+        public NonDurableDeduplicationConfiguration() { }
         public int CacheSize { get; set; }
         public override NServiceBus.Gateway.IGatewayDeduplicationStorage CreateStorage(System.IServiceProvider builder) { }
     }

--- a/src/NServiceBus.Gateway.Tests/ApprovalFiles/APIApprovals.Approve.netstandard.approved.txt
+++ b/src/NServiceBus.Gateway.Tests/ApprovalFiles/APIApprovals.Approve.netstandard.approved.txt
@@ -41,9 +41,9 @@ namespace NServiceBus.Gateway
         bool SupportsDistributedTransactions { get; }
         System.Threading.Tasks.Task<NServiceBus.Gateway.IDeduplicationSession> CheckForDuplicate(string messageId, NServiceBus.Extensibility.ContextBag context);
     }
-    public class InMemoryDeduplicationConfiguration : NServiceBus.Gateway.GatewayDeduplicationConfiguration
+    public class NonDurableDeduplicationConfiguration : NServiceBus.Gateway.GatewayDeduplicationConfiguration
     {
-        public InMemoryDeduplicationConfiguration() { }
+        public NonDurableDeduplicationConfiguration() { }
         public int CacheSize { get; set; }
         public override NServiceBus.Gateway.IGatewayDeduplicationStorage CreateStorage(System.IServiceProvider builder) { }
     }

--- a/src/NServiceBus.Gateway.Tests/NonDurableStorage/NonDurableDeduplicationConfigurationTests.cs
+++ b/src/NServiceBus.Gateway.Tests/NonDurableStorage/NonDurableDeduplicationConfigurationTests.cs
@@ -1,15 +1,15 @@
-﻿namespace NServiceBus.Gateway.Tests.InMemoryStorage
+﻿namespace NServiceBus.Gateway.Tests.NonDurableStorage
 {
     using System;
     using NUnit.Framework;
 
     [TestFixture]
-    class InMemoryDeduplicationConfigurationTests
+    class NonDurableDeduplicationConfigurationTests
     {
         [Test]
         public void Default_LRU_cache_size_is_10000()
         {
-            var configuration = new InMemoryDeduplicationConfiguration();
+            var configuration = new NonDurableDeduplicationConfiguration();
             
             Assert.AreEqual(10000, configuration.CacheSize);
         }
@@ -17,7 +17,7 @@
         [Test]
         public void Can_configure_custom_LRU_cache_size()
         {
-            var configuration = new InMemoryDeduplicationConfiguration();
+            var configuration = new NonDurableDeduplicationConfiguration();
 
             configuration.CacheSize = int.MaxValue;
             Assert.AreEqual(int.MaxValue, configuration.CacheSize);
@@ -28,7 +28,7 @@
         [Test]
         public void LRU_cache_size_needs_to_be_greater_than_zero()
         {
-            var configuration = new InMemoryDeduplicationConfiguration();
+            var configuration = new NonDurableDeduplicationConfiguration();
 
             Assert.Throws<ArgumentOutOfRangeException>(() => configuration.CacheSize = -1);
             Assert.Throws<ArgumentOutOfRangeException>(() => configuration.CacheSize = int.MinValue);

--- a/src/NServiceBus.Gateway.Tests/NonDurableStorage/NonDurableDeduplicationStorageTests.cs
+++ b/src/NServiceBus.Gateway.Tests/NonDurableStorage/NonDurableDeduplicationStorageTests.cs
@@ -1,16 +1,16 @@
-﻿namespace NServiceBus.Gateway.Tests.InMemoryStorage
+﻿namespace NServiceBus.Gateway.Tests.NonDurableStorage
 {
     using System.Threading.Tasks;
     using Extensibility;
     using NUnit.Framework;
 
     [TestFixture]
-    class InMemoryDeduplicationStorageTests
+    class NonDurableDeduplicationStorageTests
     {
         [Test]
         public async Task Should_remove_oldest_entries_when_LRU_reaches_limit()
         {
-            var storage = new InMemoryDeduplicationStorage(2);
+            var storage = new NonDurableDeduplicationStorage(2);
 
             using (var s1 = await storage.CheckForDuplicate("A", new ContextBag()))
             {

--- a/src/NServiceBus.Gateway.Tests/Recoverability/When_configuring_the_default_retry_policy_with_a_single_retry.cs
+++ b/src/NServiceBus.Gateway.Tests/Recoverability/When_configuring_the_default_retry_policy_with_a_single_retry.cs
@@ -18,7 +18,7 @@
             NumberOfRetries = 1;
 
             var config = new EndpointConfiguration("fake-endpoint");
-            config.Gateway(new InMemoryDeduplicationConfiguration()).Retries(NumberOfRetries, TimeIncrease);
+            config.Gateway(new NonDurableDeduplicationConfiguration()).Retries(NumberOfRetries, TimeIncrease);
 
             RetryPolicy = config.GetSettings().Get<Func<IncomingMessage, Exception, int, TimeSpan>>("Gateway.Retries.RetryPolicy");
         }

--- a/src/NServiceBus.Gateway.Tests/Recoverability/When_configuring_the_default_retry_policy_with_more_than_one_retry.cs
+++ b/src/NServiceBus.Gateway.Tests/Recoverability/When_configuring_the_default_retry_policy_with_more_than_one_retry.cs
@@ -18,7 +18,7 @@
             NumberOfRetries = 2;
 
             var config = new EndpointConfiguration("fake-endpoint");
-            config.Gateway(new InMemoryDeduplicationConfiguration()).Retries(NumberOfRetries, TimeIncrease);
+            config.Gateway(new NonDurableDeduplicationConfiguration()).Retries(NumberOfRetries, TimeIncrease);
 
             RetryPolicy = config.GetSettings().Get<Func<IncomingMessage, Exception, int, TimeSpan>>("Gateway.Retries.RetryPolicy");
         }

--- a/src/NServiceBus.Gateway/NonDurableStorage/NonDurableDeduplicationConfiguration.cs
+++ b/src/NServiceBus.Gateway/NonDurableStorage/NonDurableDeduplicationConfiguration.cs
@@ -5,7 +5,7 @@
     /// <summary>
     /// Configuration class for the in-memory gateway deduplication storage.
     /// </summary>
-    public class InMemoryDeduplicationConfiguration : GatewayDeduplicationConfiguration
+    public class NonDurableDeduplicationConfiguration : GatewayDeduplicationConfiguration
     {
         int cacheSize = 10000;
 
@@ -25,7 +25,7 @@
         /// <inheritdoc />
         public override IGatewayDeduplicationStorage CreateStorage(IServiceProvider builder)
         {
-            return new InMemoryDeduplicationStorage(CacheSize);
+            return new NonDurableDeduplicationStorage(CacheSize);
         }
     }
 }

--- a/src/NServiceBus.Gateway/NonDurableStorage/NonDurableDeduplicationSession.cs
+++ b/src/NServiceBus.Gateway/NonDurableStorage/NonDurableDeduplicationSession.cs
@@ -3,9 +3,9 @@
     using System.Collections.Generic;
     using System.Threading.Tasks;
 
-    class InMemoryDeduplicationSession : IDeduplicationSession
+    class NonDurableDeduplicationSession : IDeduplicationSession
     {
-        public InMemoryDeduplicationSession(string messageId, Dictionary<string, LinkedListNode<string>> clientIdSet, LinkedList<string> clientIdList, int cacheSize)
+        public NonDurableDeduplicationSession(string messageId, Dictionary<string, LinkedListNode<string>> clientIdSet, LinkedList<string> clientIdList, int cacheSize)
         {
             this.messageId = messageId;
             this.clientIdSet = clientIdSet;

--- a/src/NServiceBus.Gateway/NonDurableStorage/NonDurableDeduplicationStorage.cs
+++ b/src/NServiceBus.Gateway/NonDurableStorage/NonDurableDeduplicationStorage.cs
@@ -4,9 +4,9 @@
     using System.Threading.Tasks;
     using Extensibility;
 
-    class InMemoryDeduplicationStorage : IGatewayDeduplicationStorage
+    class NonDurableDeduplicationStorage : IGatewayDeduplicationStorage
     {
-        public InMemoryDeduplicationStorage(int cacheSize)
+        public NonDurableDeduplicationStorage(int cacheSize)
         {
             this.cacheSize = cacheSize;
         }
@@ -16,7 +16,7 @@
         public Task<IDeduplicationSession> CheckForDuplicate(string messageId, ContextBag context)
         {
             return Task.FromResult<IDeduplicationSession>(
-                new InMemoryDeduplicationSession(messageId, clientIdSet, clientIdList, cacheSize));
+                new NonDurableDeduplicationSession(messageId, clientIdSet, clientIdList, cacheSize));
         }
 
         readonly int cacheSize;


### PR DESCRIPTION
Related to _https://github.com/Particular/NServiceBus/issues/4739_

NServiceBus.Gateway contains an InMemoryDeduplicationStorage that matched the previous InMemoryPersistence. Given that the InMemory is being deprecated in favor of a separate package, we're renaming the counterparts here to match the new package called NServiceBus.Persistence.NonDurable