### PR TITLE
Implement a Gateway compatibility with linux and K8s

### DIFF
--- a/src/NServiceBus.Gateway/Gateway.cs
+++ b/src/NServiceBus.Gateway/Gateway.cs
@@ -3,6 +3,9 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+#if NETSTANDARD
+    using System.Runtime.InteropServices;
+#endif
     using System.Threading.Tasks;
     using ConsistencyGuarantees;
     using DeliveryConstraints;
@@ -117,7 +120,12 @@
                 return;
             }
 
-            CheckForNonWildcardDefaultChannel(channelManager);
+
+            var k8SIsActive = context.Settings.Get<bool>(GatewaySettings.KubernetesCompatibilityIsActive);
+            if (!k8SIsActive)
+            {
+                CheckForNonWildcardDefaultChannel(channelManager);
+            }
 
             channelReceiverFactory = s => new ChannelReceiverFactory(typeof(HttpChannelReceiver)).GetReceiver(s);
             channelSenderFactory = s => new ChannelSenderFactory(typeof(HttpChannelSender)).GetSender(s);
@@ -125,6 +133,12 @@
             var installerSettings = context.Settings.Get<InstallerSettings>();
             installerSettings.ChannelManager = channelManager;
             installerSettings.Enabled = true;
+
+#if NETSTANDARD
+           installerSettings.Enabled = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+#else
+            installerSettings.Enabled = Environment.OSVersion.Platform == PlatformID.Win32NT;
+#endif
         }
 
         static void CheckForNonWildcardDefaultChannel(IManageReceiveChannels channelManager)

--- a/src/NServiceBus.Gateway/Settings/GatewaySettings.cs
+++ b/src/NServiceBus.Gateway/Settings/GatewaySettings.cs
@@ -18,9 +18,15 @@
     /// </summary>
     public class GatewaySettings
     {
+        /// <summary>
+        /// Settings key to enable/disable K8s compatibility
+        /// </summary>
+        public const string KubernetesCompatibilityIsActive = "KubernetesCompatibilityIsActive";
+
         internal GatewaySettings(EndpointConfiguration config)
         {
             settings = config.GetSettings();
+            settings.Set(KubernetesCompatibilityIsActive, false);
         }
 
 
@@ -40,6 +46,14 @@
 
             settings.Set("GatewayChannelSenderFactory", senderFactory);
             settings.Set("GatewayChannelReceiverFactory", receiverFactory);
+        }
+
+        /// <summary>
+        /// Activate a wildcard on Kubernetes Pods avoid a CheckForNonWildcardDefaultChannel(channelManager) on feature enabling.
+        /// </summary>
+        public void ActivateKubernetesCompatibility()
+        {
+            settings.Set(KubernetesCompatibilityIsActive, true);
         }
 
 


### PR DESCRIPTION
- Enables execution in a docker container or K8s pod.
- Adds the option to disable the wildcard control in K8s pods.

Hosting the gateway in a Kubernetes pod was not possible because the installer tried to add the URL ACL. 
So we added the possibility to inform the gateway it is in a Kubernetes environment and then use wildcard binding.
