### PR TITLE
Implement a Gateway compatibility with linux and K8s

### DIFF
--- a/src/NServiceBus.Gateway/Settings/GatewaySettings.cs
+++ b/src/NServiceBus.Gateway/Settings/GatewaySettings.cs
@@ -18,9 +18,15 @@
     /// </summary>
     public class GatewaySettings
     {
+        /// <summary>
+        /// Settings key to enable/disable K8s compatibility
+        /// </summary>
+        public const string KubernetesCompatibilityIsActive = "KubernetesCompatibilityIsActive";
+
         internal GatewaySettings(EndpointConfiguration config)
         {
             settings = config.GetSettings();
+            settings.Set(KubernetesCompatibilityIsActive, false);
         }
 
 
@@ -40,6 +46,14 @@
 
             settings.Set("GatewayChannelSenderFactory", senderFactory);
             settings.Set("GatewayChannelReceiverFactory", receiverFactory);
+        }
+
+        /// <summary>
+        /// Activate a wildcard on Kubernetes Pods avoid a CheckForNonWildcardDefaultChannel(channelManager) on feature enabling.
+        /// </summary>
+        public void ActivateKubernetesCompatibility()
+        {
+            settings.Set(KubernetesCompatibilityIsActive, true);
         }
 
 
@@ -135,7 +149,7 @@
         {
             Guard.AgainstNegativeAndZero(nameof(timeout), timeout);
 
-            settings.Set("Gateway.TransactionTimeout",timeout);
+            settings.Set("Gateway.TransactionTimeout", timeout);
         }
 
         internal static TimeSpan? GetTransactionTimeout(ReadOnlySettings settings)


### PR DESCRIPTION
- Enables execution in a docker container or K8s pod.
- Adds the option to disable the wildcard control in K8s pods.

Hosting the gateway in a Kubernetes pod was not possible because the installer tried to add the URL ACL. 
We added the possibility to inform the gateway it is in a Kubernetes environment and then use wildcard binding.
