### PR TITLE
Stop using the static Current property to prevent cleanup operations to execute on the wrong endpoint

### DIFF
--- a/src/NServiceBus.Gateway.AcceptanceTests/GatewayEndpoint.cs
+++ b/src/NServiceBus.Gateway.AcceptanceTests/GatewayEndpoint.cs
@@ -13,7 +13,8 @@
             {
                 var endpointName = endpointCustomizationConfiguration.CustomEndpointName ?? configuration.GetSettings().EndpointName();
 
-                var deduplicationConfiguration = GatewayTestSuiteConstraints.Current.ConfigureDeduplicationStorage(
+                var constraints = new GatewayTestSuiteConstraints();
+                var deduplicationConfiguration = constraints.ConfigureDeduplicationStorage(
                     endpointName,
                     configuration,
                     runDescriptor.Settings)
@@ -23,7 +24,7 @@
 
                 configuration.GetSettings().Set(gatewaySettings);
 
-                runDescriptor.OnTestCompleted(_ => GatewayTestSuiteConstraints.Current.Cleanup());
+                runDescriptor.OnTestCompleted(_ => constraints.Cleanup());
 
                 configurationBuilderCustomization(configuration);
             });

--- a/src/NServiceBus.Gateway.AcceptanceTests/GatewayTestSuiteConstraints.cs
+++ b/src/NServiceBus.Gateway.AcceptanceTests/GatewayTestSuiteConstraints.cs
@@ -2,6 +2,5 @@
 {
     public partial class GatewayTestSuiteConstraints : IGatewayTestSuiteConstraints
     {
-        public static GatewayTestSuiteConstraints Current = new GatewayTestSuiteConstraints();
     }
 }


### PR DESCRIPTION
I noticed while working on the [RavenDB implementation](https://github.com/Particular/NServiceBus.Gateway.RavenDB), that when a test is composed of two or more endpoints the cleanup phase is run against the `GatewayTestSuiteConstraints` instance that has been created last.

The last endpoint that is started replaces the `Current` static that is then used in all cleanup phases.