### PR TITLE
Use C# 12 collection expressions

### DIFF
--- a/src/NServiceBus.Gateway/HeaderManagement/DataBusHeaderManager.cs
+++ b/src/NServiceBus.Gateway/HeaderManagement/DataBusHeaderManager.cs
@@ -12,7 +12,7 @@
             {
                 if (!headers.TryGetValue(clientId, out Dictionary<string, string> collection))
                 {
-                    collection = new Dictionary<string, string>();
+                    collection = [];
                     headers[clientId] = collection;
                 }
                 collection[headerKey] = headerValue;


### PR DESCRIPTION
This change satisfies the new `IDE0028` analyzer rules in the .NET 8 SDK.