### PR TITLE
Updated NServiceBus dependency to 9.2.11

### DIFF
--- a/src/NServiceBus.Gateway.AcceptanceTests/NServiceBus.Gateway.AcceptanceTests.csproj
+++ b/src/NServiceBus.Gateway.AcceptanceTests/NServiceBus.Gateway.AcceptanceTests.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="9.2.3" />
+    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="9.2.11" />
     <PackageReference Include="NServiceBus.Callbacks" Version="5.0.1" />
     <PackageReference Include="NUnit" Version="4.2.2" />
   </ItemGroup>

--- a/src/NServiceBus.Gateway/NServiceBus.Gateway.csproj
+++ b/src/NServiceBus.Gateway/NServiceBus.Gateway.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="9.2.8" />
+    <PackageReference Include="NServiceBus" Version="9.2.11" />
     <PackageReference Include="NServiceBus.ClaimCheck" Version="1.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Backport of:
- #853  

Which fixes for the release-5.1 branch:

- #843  
- #844    